### PR TITLE
added Dvorak and Colemak layers

### DIFF
--- a/keycaps-all.svg
+++ b/keycaps-all.svg
@@ -22,7 +22,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -39,13 +39,13 @@
      inkscape:window-height="1105"
      id="namedview5617"
      showgrid="false"
-     inkscape:zoom="0.42903479"
-     inkscape:cx="744.09449"
-     inkscape:cy="1052.3622"
+     inkscape:zoom="0.50797818"
+     inkscape:cx="758.26523"
+     inkscape:cy="1061.1859"
      inkscape:window-x="0"
      inkscape:window-y="1"
      inkscape:window-maximized="0"
-     inkscape:current-layer="layer17"
+     inkscape:current-layer="layer9"
      units="mm"
      inkscape:document-units="mm"
      showguides="false"
@@ -95,4848 +95,6 @@
      id="desc3357">/home/jesse/2016-12-13-keycaps-3.dxf - scale = 1.000000, origin = (0.000000, 0.000000), auto = False</desc>
   <defs
      id="defs3359">
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient17311">
-      <stop
-         style="stop-color:#000000;stop-opacity:1;"
-         offset="0"
-         id="stop17313" />
-      <stop
-         style="stop-color:#000000;stop-opacity:0;"
-         offset="1"
-         id="stop17315" />
-    </linearGradient>
-    <marker
-       id="DistanceX"
-       orient="auto"
-       refX="0"
-       refY="0"
-       style="overflow:visible">
-      <path
-         d="M 3.2,-3.2 -3.2,3.2 M 0,-5.3333333 V 5.3333333"
-         style="stroke:#000000;stroke-width:0.5"
-         id="path3362"
-         inkscape:connector-curvature="0" />
-    </marker>
-    <pattern
-       height="8"
-       id="Hatch"
-       patternUnits="userSpaceOnUse"
-       width="8"
-       x="0"
-       y="0">
-      <path
-         d="M8 4 l-4,4"
-         linecap="square"
-         stroke="#000000"
-         stroke-width="0.25"
-         id="path3365" />
-      <path
-         d="M6 2 l-4,4"
-         linecap="square"
-         stroke="#000000"
-         stroke-width="0.25"
-         id="path3367" />
-      <path
-         d="M4 0 l-4,4"
-         linecap="square"
-         stroke="#000000"
-         stroke-width="0.25"
-         id="path3369" />
-    </pattern>
-    <symbol
-       id="*MODEL_SPACE" />
-    <symbol
-       id="*PAPER_SPACE" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16773">
-      <path
-         d="m 689.99147,555.19787 h 2.11733 v 7.7568 l -2.1184,0.001 z"
-         id="path16775"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16793">
-      <path
-         d="m 679.48373,560.3168 9.65974,0.001 v 7.3632 h -9.65974 z"
-         id="path16795"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16805">
-      <path
-         d="m 683.26187,559.5232 10e-4,-6.7104 h 6.28694 l -10e-4,6.7104 z"
-         id="path16807"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16817">
-      <path
-         d="m 692.94187,567.68 v -7.3632 l 9.6608,0.001 10e-4,7.3632 z"
-         id="path16819"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath16829">
-      <path
-         d="m 692.5376,559.5232 -10e-4,-6.7104 h 6.288 l 10e-4,6.7104 z"
-         id="path16831"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17331"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17517"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17525"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17651"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17666"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17674"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17853"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17868"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient17876"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18103"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18118"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18126"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18319"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(33.060747,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18427"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18334"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18342"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18473"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18488"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18496"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18665"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18667"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18747"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18750"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18752"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18794"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18809"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18817"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18945"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18960"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient18968"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19134"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(33.060747,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19137"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19139"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(36.930777,106.0528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19222"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(33.060747,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19330"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19237"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient19245"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24823"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24831"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(36.930777,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24846"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(33.060747,106.0528)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25000"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(152.39381,111.15013)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24937"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(152.39381,111.15013)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24945"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(152.39381,111.15013)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25109"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25046"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25054"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25429"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25366"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25374"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25483"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25485"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25487"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25489"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25502"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25504"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32384"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32704"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32399"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32407"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32708"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32422"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32711"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32437"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32445"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32460"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32718"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32475"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32483"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32722"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32498"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32725"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32513"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32521"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32800"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(148.52378,111.15013)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33120"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32815"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32823"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33124"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32838"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33127"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32853"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32861"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33131"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32876"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33134"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32891"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32899"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33138"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32914"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient33141"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32929"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient32937"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37704"
-       gradientUnits="userSpaceOnUse"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425"
-       gradientTransform="translate(148.52378,111.15013)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38024"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37719"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37727"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38028"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37742"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38031"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37757"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37765"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38035"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37780"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38038"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37795"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37803"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38042"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37818"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38045"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37833"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient37841"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38166"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38486"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38490"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38204"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38493"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38497"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38242"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38500"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38257"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38265"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38504"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38280"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38507"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38295"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38303"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38701"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38703"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38705"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38707"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38709"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38711"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38713"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38717"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38719"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38721"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38723"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38725"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38727"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38729"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38731"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38733"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38735"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38737"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38814"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39134"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38829"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38837"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39138"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38852"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39141"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38867"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38875"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39145"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38890"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39148"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38905"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38913"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39155"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38943"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient38951"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39349"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39351"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39353"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39355"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39357"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39359"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39361"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39363"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39365"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39367"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39369"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39371"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39373"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39375"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39377"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39379"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39381"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39383"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient39385"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48700"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48778"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48723"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48809"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48887"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48824"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient48832"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49024"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49039"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49047"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49130"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49145"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient49153"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(152.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13640"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13956"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13655"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13663"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13960"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13678"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13963"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13693"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13701"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13716"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13724"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13739"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13972"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13754"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13975"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13769"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13777"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14591"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14929"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14606"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14614"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14629"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14936"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14644"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14652"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14940"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14667"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14943"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14682"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14690"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14947"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14705"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14950"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14720"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14728"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15164"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15166"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15168"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15170"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15172"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15174"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15176"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15180"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15182"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15186"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15188"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15194"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15196"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15198"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15408"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15410"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15412"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15414"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15416"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15418"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15420"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15422"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15424"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15426"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15430"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15432"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15434"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15436"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15438"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15440"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15442"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15444"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15654"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15656"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15658"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15660"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15664"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15666"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15670"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15672"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15674"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15676"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15678"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15680"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15682"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15684"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15686"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15688"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15690"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15900"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15902"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15904"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15906"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15908"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15910"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15912"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15914"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15918"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15920"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15922"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15924"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15926"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15928"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15930"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15934"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient15936"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16146"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16148"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16150"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16154"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16156"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16158"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16160"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16162"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16164"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16166"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16168"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16170"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16172"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16174"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16176"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16178"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16180"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16182"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16281"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16289"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16319"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16327"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16342"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16357"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16365"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16380"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16395"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient16403"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11502"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11758"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11517"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11525"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11762"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11540"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11765"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11555"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11563"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11769"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11578"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11593"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11601"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11842"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12180"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11857"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11865"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12184"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11880"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12187"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11895"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11903"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12191"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11918"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12194"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11933"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11941"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12198"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11956"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12201"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11971"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient11979"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12287"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12625"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12302"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12310"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12629"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12325"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12632"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12340"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12348"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12636"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12363"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12639"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12378"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12386"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12643"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12401"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12646"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12416"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12424"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12732"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13070"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12747"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12755"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13074"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12770"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13077"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12785"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12793"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13081"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12808"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13084"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12823"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12831"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13088"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12846"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13091"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12861"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient12869"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13177"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13515"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13192"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13200"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13519"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13522"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13230"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13238"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13526"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13253"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13529"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13268"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13276"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13533"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13291"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13536"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13306"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13314"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13961"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13637"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13645"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13965"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13660"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13968"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13675"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13683"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13973"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13698"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13976"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13713"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13721"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13980"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13736"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13983"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13751"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient13759"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14069"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14084"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14092"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-939.41417)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14107"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(518.09133,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14122"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14130"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(517.96136,-875.63467)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14145"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14160"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14168"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14183"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14198"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient14206"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient7365"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.52378,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient7447"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient7380"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient7388"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(148.39381,111.15013)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27934">
-      <path
-         d="m 689.99147,555.19787 h 2.11733 v 7.7568 l -2.1184,0.001 z"
-         id="path27936"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27954">
-      <path
-         d="m 679.48373,560.3168 9.65974,0.001 v 7.3632 h -9.65974 z"
-         id="path27956"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27966">
-      <path
-         d="m 683.26187,559.5232 10e-4,-6.7104 h 6.28694 l -10e-4,6.7104 z"
-         id="path27968"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27978">
-      <path
-         d="m 692.94187,567.68 v -7.3632 l 9.6608,0.001 10e-4,7.3632 z"
-         id="path27980"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27990">
-      <path
-         d="m 692.5376,559.5232 -10e-4,-6.7104 h 6.288 l 10e-4,6.7104 z"
-         id="path27992"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
     <inkscape:path-effect
        effect="spiro"
        id="path-effect30114"
@@ -4961,3311 +119,6 @@
        is_visible="true"
        id="path-effect9087-4"
        effect="spiro" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient119863"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120004"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient119878"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120122"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120137"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120864"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54042,-1061.6985)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125217"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-1061.6985)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120879"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-1061.6985)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125220"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54042,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120894"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54042,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120909"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120917"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120932"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54045,-857.60396)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125228"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40181,-857.60396)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120947"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40181,-857.60396)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120962"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54045,-925.63543)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125233"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40181,-925.63543)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120977"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40181,-925.63543)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125236"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.27257,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient120992"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.27257,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121007"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121023"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125243"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.27257,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121038"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.27257,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13394,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121061"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13394,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125249"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.2726,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.2726,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121091"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121099"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125255"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.2726,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121114"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.2726,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121129"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121137"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125261"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06188,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121152"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06188,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121167"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92324,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121175"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92324,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125267"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06189,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06189,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121205"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92325,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121213"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92325,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125273"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06198,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121228"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06198,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121243"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121251"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125279"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06198,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,696.06198,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121281"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121289"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125285"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.08395,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.08395,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121319"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94532,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121327"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94532,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125291"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.08397,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121342"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.08397,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121357"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94534,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121365"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94534,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125297"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.0843,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121380"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.0843,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121395"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121403"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125303"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.0843,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121418"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,776.0843,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121433"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121441"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121456"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-992.80899)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125311"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-992.80899)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121471"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-992.80899)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121486"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-907.71086)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125316"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-907.71086)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121501"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-907.71086)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125319"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121516"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121531"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121539"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125325"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121554"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121569"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121577"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125331"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121592"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121607"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121615"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121630"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.84221,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121645"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121653"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125343"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121683"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121691"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125349"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121706"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121721"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121729"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125355"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121744"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121759"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121767"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125361"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121782"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.83077,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121797"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121805"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121820"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1179.6176,-1035.2437)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125369"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1183.7456,-1035.2437)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121835"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1183.7456,-1035.2437)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121850"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient125374"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient121865"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.59635,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129716"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-1077.9072)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129756"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129764"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1064.8786)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129812"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-992.80899)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129852"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129860"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-996.84701)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129908"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1012.008)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129964"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient129972"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1080.0395)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130020"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130028"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-1132.9101)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130076"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130084"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-1148.071)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130132"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94532,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130140"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94532,-1143.1472)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130188"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92324,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130196"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92324,-1118.1384)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130244"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92325,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130252"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92325,-1050.1069)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130300"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94534,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130308"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94534,-1075.1157)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130356"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130364"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130372"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13393,-1061.7787)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130428"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54042,-1061.6985)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130468"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130476"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.40179,-993.667)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130524"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13394,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130532"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13394,-993.74723)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130580"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54045,-925.63543)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130620"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,527.54045,-857.60396)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130660"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130668"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-857.68419)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130716"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130724"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,599.13396,-925.71566)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130772"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130780"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-982.07528)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130828"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130836"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,695.92335,-914.04381)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130884"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130892"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-939.05257)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130940"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130948"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,775.94567,-1007.084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient130996"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131004"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,855.70357,-943.97649)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131052"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,927.69214,-928.81554)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131108"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,999.73499,-907.71086)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131220"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1179.6176,-1035.2437)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131740"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.756,-1142.94)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131755"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1142.94)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131763"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1142.94)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-908.15991)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131778"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-908.15991)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-908.15991)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131793"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-908.15991)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27934-0">
-      <path
-         d="m 689.99147,555.19787 2.11733,0 0,7.7568 -2.1184,0.001 z"
-         id="path27936-2"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27954-5">
-      <path
-         d="m 679.48373,560.3168 9.65974,0.001 0,7.3632 -9.65974,0 z"
-         id="path27956-5"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27966-5">
-      <path
-         d="m 683.26187,559.5232 10e-4,-6.7104 6.28694,0 -10e-4,6.7104 z"
-         id="path27968-5"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27978-9">
-      <path
-         d="m 692.94187,567.68 0,-7.3632 9.6608,0.001 10e-4,7.3632 z"
-         id="path27980-6"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <clipPath
-       clipPathUnits="userSpaceOnUse"
-       id="clipPath27990-8">
-      <path
-         d="m 692.5376,559.5232 -10e-4,-6.7104 6.288,0 10e-4,6.7104 z"
-         id="path27992-3"
-         inkscape:connector-curvature="0"
-         style="stroke-width:1px" />
-    </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131818"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-993.25805)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136281"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-993.25805)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131833"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-993.25805)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131848"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1210.9715)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136286"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1210.9715)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131863"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1210.9715)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136289"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131878"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131893"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131901"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136295"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131916"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131931"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131939"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136301"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6924,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131954"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6924,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131969"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131977"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136307"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6924,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient131992"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6924,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132007"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5538,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132015"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5538,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136313"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6923,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132030"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6923,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132045"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132053"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136319"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6923,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132068"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.6923,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132083"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132091"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136325"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5609,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132106"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5609,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132121"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132129"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136331"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5609,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132144"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5609,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132159"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4223,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132167"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4223,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5608,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132182"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5608,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132205"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136343"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5608,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132220"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.5608,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132235"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132243"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132251"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136350"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3392,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132266"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3392,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132281"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132289"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136356"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3391,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132304"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3391,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132319"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132327"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136362"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3388,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132342"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3388,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132357"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132365"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136368"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3388,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132380"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.3388,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132395"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132403"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132411"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136375"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132426"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132441"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132449"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136381"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132464"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132479"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132487"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136387"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132502"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132517"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132525"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136393"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132540"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.5574,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132555"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132563"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132571"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136400"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132586"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132601"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132609"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136406"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132624"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132639"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132647"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136412"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132662"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132677"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132685"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136418"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132700"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.8096,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132715"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132723"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132731"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132746"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136427"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132761"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.0175,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132776"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,879.57893,-241.62778)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient136432"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,879.4403,-241.62778)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient132791"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,879.4403,-241.62778)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23774"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-1078.3563)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23814"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1256.1561,-993.25805)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23854"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23862"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1133.5834)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23910"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23918"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.6709,-1065.5519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23966"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23974"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient23982"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-997.52037)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24038"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24046"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1148.9041)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24094"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24102"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4188,-1080.8726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24150"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24158"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24166"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-1012.841)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24222"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24230"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1173.7575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24278"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24286"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2005,-1105.726)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24334"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24342"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24350"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-1037.6946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24406"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24414"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1479.2001,-969.66312)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24462"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24470"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1178.6141)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24518"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4223,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24526"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4223,-1110.5826)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24574"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24582"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24590"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-1042.551)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24646"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24654"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1210.7289)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24702"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5538,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24710"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5538,-1142.6974)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24758"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24766"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1074.6658)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24814"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24822"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1649.5537,-1006.6344)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24870"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.7559,-1210.9715)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24910"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1142.94)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24918"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6173,-1142.94)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24966"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient24974"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1074.9084)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25022"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25030"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1721.6172,-1006.877)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25078"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25086"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1558.4222,-974.51956)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25134"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25142"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1399.4187,-944.80954)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25190"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25198"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,1327.671,-929.4889)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
     <clipPath
        clipPathUnits="userSpaceOnUse"
        id="clipPath27934-0-2">
@@ -8311,572 +164,57 @@
          inkscape:connector-curvature="0"
          style="stroke-width:1px" />
     </clipPath>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient25438"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1.0666667,0,0,1.0666667,879.57893,-241.62778)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53177"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.678591,-37.397308)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53179"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.934042,-37.298717)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53181"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.919526,-37.510455)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53183"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.748516,-37.532233)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53185"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.377828,-37.594035)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53187"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.672016,-37.455806)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53189"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.839022,-37.456402)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53191"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.701491,-37.426403)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53193"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.607211,-37.424416)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53195"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.326498,-37.398442)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53197"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.11876,-37.492703)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53199"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.01271,-37.4519)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53201"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.214449,-37.44436)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53203"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.535863,-37.413351)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53205"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.169862,-37.538339)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53207"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.975025,-37.537875)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53209"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.31999,-37.449724)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53211"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.450098,-37.425866)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53213"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.986617,-37.406515)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53215"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.104996,-37.42603)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53217"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.42022,-37.487614)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53219"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.903969,-37.410067)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53221"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.353531,-37.53631)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53223"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-57.800888,-37.435514)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53225"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.135613,-37.459982)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53227"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.255109,-37.438644)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53229"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-58.658066,-37.432771)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53231"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.15667,-37.115589)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53233"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18769,-37.377912)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53235"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18679,-37.365511)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53237"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.30735,-37.362996)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53239"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.19146,-37.38005)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53241"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.30617,-37.383688)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53243"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18518,-37.388067)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53245"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.31358,-37.349089)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53247"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18494,-37.375089)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53249"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.1725,-37.401379)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53251"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.1801,-37.376774)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53253"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.30232,-37.392192)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53255"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.19684,-37.399766)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53257"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.19752,-37.391004)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53259"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18642,-37.387946)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53261"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.20272,-37.401043)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53263"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.31278,-37.369731)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53265"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18573,-37.372134)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53267"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18287,-37.39274)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53269"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18144,-37.411666)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53271"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.20043,-37.382244)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53273"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.20715,-37.379855)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53275"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.31417,-37.384653)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53277"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.19525,-37.381017)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53279"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18295,-37.382443)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53281"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18521,-37.432575)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53283"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18932,-37.396133)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient17311"
-       id="linearGradient53285"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(587.18659,-37.407853)"
-       x1="-299.46213"
-       y1="1419.9413"
-       x2="-288.13068"
-       y2="1473.6425" />
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27934-0-2-8">
+      <path
+         d="m 689.99147,555.19787 2.11733,0 0,7.7568 -2.1184,0.001 z"
+         id="path27936-2-8-2"
+         inkscape:connector-curvature="0"
+         style="stroke-width:1px" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27954-5-3-6">
+      <path
+         d="m 679.48373,560.3168 9.65974,0.001 0,7.3632 -9.65974,0 z"
+         id="path27956-5-2-7"
+         inkscape:connector-curvature="0"
+         style="stroke-width:1px" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27966-5-4-1">
+      <path
+         d="m 683.26187,559.5232 10e-4,-6.7104 6.28694,0 -10e-4,6.7104 z"
+         id="path27968-5-5-3"
+         inkscape:connector-curvature="0"
+         style="stroke-width:1px" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27978-9-3-9">
+      <path
+         d="m 692.94187,567.68 0,-7.3632 9.6608,0.001 10e-4,7.3632 z"
+         id="path27980-6-9-7"
+         inkscape:connector-curvature="0"
+         style="stroke-width:1px" />
+    </clipPath>
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath27990-8-0-6">
+      <path
+         d="m 692.5376,559.5232 -10e-4,-6.7104 6.288,0 10e-4,6.7104 z"
+         id="path27992-3-2-2"
+         inkscape:connector-curvature="0"
+         style="stroke-width:1px" />
+    </clipPath>
   </defs>
   <g
      inkscape:groupmode="layer"
      id="layer6"
      inkscape:label="jig"
-     style="display:inline">
+     style="display:none">
     <path
        inkscape:transform-center-y="-272.63519"
        inkscape:transform-center-x="190.27195"
@@ -23443,7 +14781,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53285);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06317"
            y="1222.3207"
            id="text17040-4-2-8-6-6"
@@ -23451,12 +14789,12 @@
              sodipodi:role="line"
              x="306.06317"
              y="1222.3207"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53285);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-4">　</tspan><tspan
              sodipodi:role="line"
              x="306.06317"
              y="1242.5941"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53285);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392650">B</tspan></text>
       </g>
       <g
@@ -23480,7 +14818,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53283);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06589"
            y="1222.3324"
            id="text17040-4-2-8-6-1"
@@ -23488,12 +14826,12 @@
              sodipodi:role="line"
              x="306.06589"
              y="1222.3324"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53283);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-9">　</tspan><tspan
              sodipodi:role="line"
              x="306.06589"
              y="1242.6058"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53283);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392654">V</tspan></text>
       </g>
       <g
@@ -23517,7 +14855,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53281);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06183"
            y="1222.2959"
            id="text17040-4-2-8-6-2"
@@ -23525,12 +14863,12 @@
              sodipodi:role="line"
              x="306.06183"
              y="1222.2959"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53281);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-43">　</tspan><tspan
              sodipodi:role="line"
              x="306.06183"
              y="1242.5693"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53281);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392662">X</tspan></text>
       </g>
       <g
@@ -23554,7 +14892,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53279);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.05954"
            y="1222.3461"
            id="text17040-4-2-8-1-7"
@@ -23562,12 +14900,12 @@
              sodipodi:role="line"
              x="306.05954"
              y="1222.3461"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53279);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-5-2">　</tspan><tspan
              sodipodi:role="line"
              x="306.05954"
              y="1242.6195"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53279);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-2">T</tspan></text>
       </g>
       <g
@@ -23591,7 +14929,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53277);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.07187"
            y="1222.3474"
            id="text17040-4-2-8-0"
@@ -23599,12 +14937,12 @@
              sodipodi:role="line"
              x="306.07187"
              y="1222.3474"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53277);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-40">　</tspan><tspan
              sodipodi:role="line"
              x="306.07187"
              y="1242.6208"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53277);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-91">S</tspan></text>
       </g>
       <g
@@ -23630,10 +14968,10 @@
            id="text17018-5-4-1-04"
            y="1240.7863"
            x="305.57327"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53275);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53275);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1240.7863"
              x="305.57327"
              id="tspan17020-6-0-9-88"
@@ -23660,7 +14998,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53273);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.08371"
            y="1222.3486"
            id="text17040-4-2-8-7-4"
@@ -23668,12 +15006,12 @@
              sodipodi:role="line"
              x="306.08371"
              y="1222.3486"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53273);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-8">$</tspan><tspan
              sodipodi:role="line"
              x="306.08371"
              y="1242.6221"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53273);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431653">4</tspan></text>
       </g>
       <g
@@ -23697,7 +15035,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53271);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.07706"
            y="1222.3463"
            id="text17040-4-2-8-1-41"
@@ -23705,12 +15043,12 @@
              sodipodi:role="line"
              x="306.07706"
              y="1222.3463"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53271);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-8">　</tspan><tspan
              sodipodi:role="line"
              x="306.07706"
              y="1242.6198"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53271);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan349792">W</tspan></text>
       </g>
       <g
@@ -23734,7 +15072,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53269);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.05801"
            y="1222.3168"
            id="text17040-4-2-8-6-0"
@@ -23742,12 +15080,12 @@
              sodipodi:role="line"
              x="306.05801"
              y="1222.3168"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53269);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-64">　</tspan><tspan
              sodipodi:role="line"
              x="306.05801"
              y="1242.5902"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53269);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392658">C</tspan></text>
       </g>
       <g
@@ -23771,7 +15109,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53267);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.05942"
            y="1222.3358"
            id="text17040-4-2-8-2"
@@ -23779,12 +15117,12 @@
              sodipodi:role="line"
              x="306.05942"
              y="1222.3358"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53267);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-93">　</tspan><tspan
              sodipodi:role="line"
              x="306.05942"
              y="1242.6093"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53267);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-9">F</tspan></text>
       </g>
       <g
@@ -23808,7 +15146,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53265);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06232"
            y="1222.3564"
            id="text17040-4-2-8-1-72"
@@ -23816,12 +15154,12 @@
              sodipodi:role="line"
              x="306.06232"
              y="1222.3564"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53265);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-99">　</tspan><tspan
              sodipodi:role="line"
              x="306.06232"
              y="1242.6299"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53265);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392612">E</tspan></text>
       </g>
       <g
@@ -23845,7 +15183,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53263);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="305.57193"
            y="1240.8011"
            id="text17018-5-4-1-7-93-0"
@@ -23854,7 +15192,7 @@
              id="tspan17020-6-0-9-5-9-7"
              x="305.57193"
              y="1240.8011"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53263);fill-opacity:1;stroke-width:1px">pgdn</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">pgdn</tspan></text>
       </g>
       <g
          style="display:inline;stroke:#280b0b;stroke-width:0.9375"
@@ -23877,7 +15215,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53261);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.07935"
            y="1222.3274"
            id="text17040-4-2-8-1-49"
@@ -23885,12 +15223,12 @@
              sodipodi:role="line"
              x="306.07935"
              y="1222.3274"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53261);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-4">　</tspan><tspan
              sodipodi:role="line"
              x="306.07935"
              y="1242.6008"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53261);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan349788">Q</tspan></text>
       </g>
       <g
@@ -23914,7 +15252,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53259);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06302"
            y="1222.3406"
            id="text17040-4-2-8-11"
@@ -23922,12 +15260,12 @@
              sodipodi:role="line"
              x="306.06302"
              y="1222.3406"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53259);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-0">　</tspan><tspan
              sodipodi:role="line"
              x="306.06302"
              y="1242.614"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53259);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-34">D</tspan></text>
       </g>
       <g
@@ -23951,7 +15289,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53257);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.07413"
            y="1222.3375"
            id="text17040-4-2-8-9"
@@ -23959,12 +15297,12 @@
              sodipodi:role="line"
              x="306.07413"
              y="1222.3375"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53257);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-60">　</tspan><tspan
              sodipodi:role="line"
              x="306.07413"
              y="1242.611"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53257);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-4">A</tspan></text>
       </g>
       <g
@@ -23988,7 +15326,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53255);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.07346"
            y="1222.3287"
            id="text17040-4-2-8-6-28"
@@ -23996,12 +15334,12 @@
              sodipodi:role="line"
              x="306.07346"
              y="1222.3287"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53255);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-0">　</tspan><tspan
              sodipodi:role="line"
              x="306.07346"
              y="1242.6022"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53255);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392666">Z</tspan></text>
       </g>
       <g
@@ -24025,7 +15363,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53253);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="305.56143"
            y="1240.7787"
            id="text17018-5-4-1-7-0"
@@ -24034,7 +15372,7 @@
              id="tspan17020-6-0-9-5-5"
              x="305.56143"
              y="1240.7787"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53253);fill-opacity:1;stroke-width:1px">esc</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">esc</tspan></text>
       </g>
       <g
          style="display:inline;stroke:#280b0b;stroke-width:0.9375"
@@ -24057,7 +15395,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53251);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.05667"
            y="1222.3518"
            id="text17040-4-2-8-7-0"
@@ -24065,12 +15403,12 @@
              sodipodi:role="line"
              x="306.05667"
              y="1222.3518"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53251);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-1">%</tspan><tspan
              sodipodi:role="line"
              x="306.05667"
              y="1242.6252"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53251);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431657">5</tspan></text>
       </g>
       <g
@@ -24094,7 +15432,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53249);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.04913"
            y="1222.3271"
            id="text17040-4-2-8-1-49-0"
@@ -24102,12 +15440,12 @@
              sodipodi:role="line"
              x="306.04913"
              y="1222.3271"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53249);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-4-9">~</tspan><tspan
              sodipodi:role="line"
              x="306.04913"
              y="1242.6006"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53249);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392676">`</tspan></text>
       </g>
       <g
@@ -24131,7 +15469,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53247);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06152"
            y="1222.3534"
            id="text17040-4-2-8-8"
@@ -24139,12 +15477,12 @@
              sodipodi:role="line"
              x="306.06152"
              y="1222.3534"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53247);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-3">　</tspan><tspan
              sodipodi:role="line"
              x="306.06152"
              y="1242.6268"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53247);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392640">G</tspan></text>
       </g>
       <g
@@ -24168,7 +15506,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53245);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="305.57275"
            y="1240.8219"
            id="text17018-5-4-1-5-2-3"
@@ -24177,7 +15515,7 @@
              id="tspan17020-6-0-9-9-5-7"
              x="305.57275"
              y="1240.8219"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53245);fill-opacity:1;stroke-width:1px">prog</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">prog</tspan></text>
       </g>
       <g
          style="display:inline;stroke:#280b0b;stroke-width:0.9375"
@@ -24200,7 +15538,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53243);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06177"
            y="1222.3405"
            id="text17040-4-2-8-7-7"
@@ -24208,12 +15546,12 @@
              sodipodi:role="line"
              x="306.06177"
              y="1222.3405"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53243);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-7">#</tspan><tspan
              sodipodi:role="line"
              x="306.06177"
              y="1242.6139"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53243);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431649">3</tspan></text>
       </g>
       <g
@@ -24237,7 +15575,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53241);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="305.56534"
            y="1240.7872"
            id="text17018-5-4-1-58-8"
@@ -24246,7 +15584,7 @@
              id="tspan17020-6-0-9-7-2"
              x="305.56534"
              y="1240.7872"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53241);fill-opacity:1;stroke-width:1px">pgup</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">pgup</tspan></text>
       </g>
       <g
          style="display:inline;stroke:#280b0b;stroke-width:0.9375"
@@ -24269,7 +15607,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53239);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06799"
            y="1222.3484"
            id="text17040-4-2-8-1-4"
@@ -24277,12 +15615,12 @@
              sodipodi:role="line"
              x="306.06799"
              y="1222.3484"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53239);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-7">　</tspan><tspan
              sodipodi:role="line"
              x="306.06799"
              y="1242.6218"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53239);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392616">R</tspan></text>
       </g>
       <g
@@ -24308,10 +15646,10 @@
            id="text17018-5-4-1-0-8-7"
            y="1240.8077"
            x="305.56647"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53237);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53237);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1240.8077"
              x="305.56647"
              id="tspan17020-6-0-9-54-1-8"
@@ -24338,7 +15676,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53235);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.06342"
            y="1222.363"
            id="text17040-4-2-8-7-34"
@@ -24346,17 +15684,17 @@
              sodipodi:role="line"
              x="306.06342"
              y="1222.363"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53235);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-2">!</tspan><tspan
              sodipodi:role="line"
              x="306.06342"
              y="1242.6365"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53235);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392680">1</tspan><tspan
              sodipodi:role="line"
              x="306.06342"
              y="1262.9099"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53235);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan392682" /></text>
       </g>
       <g
@@ -24380,7 +15718,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53233);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="306.0643"
            y="1222.3507"
            id="text17040-4-2-8-7-8"
@@ -24388,12 +15726,12 @@
              sodipodi:role="line"
              x="306.0643"
              y="1222.3507"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53233);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-4">@</tspan><tspan
              sodipodi:role="line"
              x="306.0643"
              y="1242.6241"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53233);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431645">2</tspan></text>
       </g>
       <g
@@ -24423,7 +15761,7 @@
            xml:space="preserve"
            transform="matrix(0,-1,-1,0,0,0)"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.71399"
              x="-1208.2581"
              id="tspan17020-6-8-1-7-9-0-7"
@@ -24456,7 +15794,7 @@
            xml:space="preserve"
            transform="matrix(0,-1,-1,0,0,0)"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-300.0101"
              x="-1207.9635"
              id="tspan17020-6-8-1-7-9-0"
@@ -24489,7 +15827,7 @@
            xml:space="preserve"
            transform="matrix(0,-1,-1,0,0,0)"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.74393"
              x="-1208.2621"
              id="tspan17020-6-8-1-7-9"
@@ -24522,7 +15860,7 @@
            xml:space="preserve"
            transform="matrix(0,-1,-1,0,0,0)"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.89603"
              x="-1208.0164"
              id="tspan17020-6-8-1-7"
@@ -24551,10 +15889,10 @@
            id="text17018-5-4-1-5-8-0"
            y="1241.0553"
            x="321.10257"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53231);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:url(#linearGradient53231);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1241.0553"
              x="321.10257"
              id="tspan17020-6-0-9-9-49-3"
@@ -24581,7 +15919,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53229);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.78146"
            y="1222.2958"
            id="text17040-4-2-8-6-28-8"
@@ -24590,12 +15928,12 @@
              sodipodi:role="line"
              x="-339.78146"
              y="1222.2958"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53229);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431725">?   \</tspan><tspan
              sodipodi:role="line"
              x="-339.78146"
              y="1242.5692"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53229);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431729">/</tspan></text>
       </g>
       <g
@@ -24619,7 +15957,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53227);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.37842"
            y="1222.2899"
            id="text17040-4-2-8-1-49-7"
@@ -24628,12 +15966,12 @@
              sodipodi:role="line"
              x="-339.37842"
              y="1222.2899"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53227);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-4-6">　 ]</tspan><tspan
              sodipodi:role="line"
              x="-339.37842"
              y="1242.5634"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53227);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431709">P</tspan></text>
       </g>
       <g
@@ -24657,7 +15995,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53225);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.25903"
            y="1222.2686"
            id="text17040-4-2-8-1-4-6"
@@ -24666,12 +16004,12 @@
              sodipodi:role="line"
              x="-339.25903"
              y="1222.2686"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53225);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-7-9">　  {</tspan><tspan
              sodipodi:role="line"
              x="-339.25903"
              y="1242.542"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53225);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431697">U</tspan></text>
       </g>
       <g
@@ -24697,16 +16035,16 @@
            id="text17040-4-2-8-7-0-6"
            y="1222.293"
            x="-338.92413"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53223);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"
            transform="scale(-1,1)"><tspan
              id="tspan17060-8-2-76-6-1-9"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53223);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1222.293"
              x="-338.92413"
              sodipodi:role="line">^</tspan><tspan
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53223);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1242.5664"
              x="-338.92413"
              sodipodi:role="line"
@@ -24733,7 +16071,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53221);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.47693"
            y="1222.1923"
            id="text17040-4-2-8-6-28-8-2"
@@ -24742,12 +16080,12 @@
              sodipodi:role="line"
              x="-339.47693"
              y="1222.1923"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53221);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-0-5-3">_   |</tspan><tspan
              sodipodi:role="line"
              x="-339.47693"
              y="1242.4657"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53221);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431733">-</tspan></text>
       </g>
       <g
@@ -24771,7 +16109,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53219);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.0274"
            y="1222.3184"
            id="text17040-4-2-8-1-72-5"
@@ -24780,12 +16118,12 @@
              sodipodi:role="line"
              x="-339.0274"
              y="1222.3184"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53219);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-5-82-3">　  }</tspan><tspan
              sodipodi:role="line"
              x="-339.0274"
              y="1242.5918"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53219);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-99-8">I</tspan></text>
       </g>
       <g
@@ -24809,7 +16147,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53217);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.54364"
            y="1222.2408"
            id="text17040-4-2-8-6-6-3"
@@ -24818,12 +16156,12 @@
              sodipodi:role="line"
              x="-339.54364"
              y="1222.2408"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53217);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-9-6-7">　</tspan><tspan
              sodipodi:role="line"
              x="-339.54364"
              y="1242.5143"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53217);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-4-4">N</tspan></text>
       </g>
       <g
@@ -24847,7 +16185,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53215);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.22824"
            y="1222.3026"
            id="text17040-4-2-8-11-4"
@@ -24856,14 +16194,14 @@
              sodipodi:role="line"
              x="-339.22824"
              y="1222.3026"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53215);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-0-4">　 <tspan
-   style="font-weight:bold;fill:url(#linearGradient53215)"
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
    id="tspan497575">↑</tspan></tspan><tspan
              sodipodi:role="line"
              x="-339.22824"
              y="1242.9333"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53215);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-34-4">K</tspan></text>
       </g>
       <g
@@ -24887,7 +16225,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53213);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.11005"
            y="1222.322"
            id="text17040-4-2-8-7-34-0"
@@ -24896,12 +16234,13 @@
              sodipodi:role="line"
              x="-339.11005"
              y="1222.322"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53213);fill-opacity:1;stroke-width:1px"
-             id="tspan17060-8-2-76-6-2-7">)</tspan><tspan
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-2-7"
+             dx="2">)</tspan><tspan
              sodipodi:role="line"
              x="-339.11005"
              y="1242.5955"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53213);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431687">0</tspan></text>
       </g>
       <g
@@ -24925,7 +16264,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53211);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.57346"
            y="1222.3026"
            id="text17040-4-2-8-9-0"
@@ -24934,12 +16273,12 @@
              sodipodi:role="line"
              x="-339.57346"
              y="1222.3026"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53211);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-4-4">:</tspan><tspan
              sodipodi:role="line"
              x="-339.57346"
              y="1242.576"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53211);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431741">;</tspan></text>
       </g>
       <g
@@ -25094,7 +16433,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53209);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.44339"
            y="1222.2788"
            id="text17040-4-2-8-6-0-2"
@@ -25103,12 +16442,12 @@
              sodipodi:role="line"
              x="-339.44339"
              y="1222.2788"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53209);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-64-7">&lt;</tspan><tspan
              sodipodi:role="line"
              x="-339.44339"
              y="1242.5522"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53209);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431717">,</tspan></text>
       </g>
       <g
@@ -25132,7 +16471,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53207);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.09845"
            y="1222.1907"
            id="text17040-4-2-8-1-41-1"
@@ -25141,12 +16480,12 @@
              sodipodi:role="line"
              x="-339.09845"
              y="1222.1907"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53207);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-5-28-0">　  [</tspan><tspan
              sodipodi:role="line"
              x="-339.09845"
              y="1242.4641"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53207);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-8-5">O</tspan></text>
       </g>
       <g
@@ -25170,7 +16509,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53205);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.2933"
            y="1222.1902"
            id="text17040-4-2-8-0-4"
@@ -25179,14 +16518,14 @@
              sodipodi:role="line"
              x="-339.2933"
              y="1222.1902"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53205);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-40-0">　 <tspan
-   style="font-weight:bold;fill:url(#linearGradient53205)"
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
    id="tspan497573">→</tspan></tspan><tspan
              sodipodi:role="line"
              x="-339.2933"
              y="1242.8209"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53205);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-91-5">L</tspan></text>
       </g>
       <g
@@ -25210,7 +16549,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53203);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.65924"
            y="1222.3152"
            id="text17040-4-2-8-6-1-7"
@@ -25219,12 +16558,12 @@
              sodipodi:role="line"
              x="-339.65924"
              y="1222.3152"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53203);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-9-5-1">　</tspan><tspan
              sodipodi:role="line"
              x="-339.65924"
              y="1242.5886"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53203);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-9-1">M</tspan></text>
       </g>
       <g
@@ -25248,7 +16587,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53201);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.33786"
            y="1222.2842"
            id="text17040-4-2-8-8-2"
@@ -25257,14 +16596,14 @@
              sodipodi:role="line"
              x="-339.33786"
              y="1222.2842"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53201);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-4-0">　 <tspan
-   style="font-weight:bold;fill:url(#linearGradient53201)"
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
    id="tspan497579">←</tspan></tspan><tspan
              sodipodi:role="line"
              x="-339.33786"
              y="1242.9149"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53201);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-3-6">H</tspan></text>
       </g>
       <g
@@ -25288,7 +16627,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53199);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.13602"
            y="1222.2766"
            id="text17040-4-2-8-1-7-7"
@@ -25297,12 +16636,12 @@
              sodipodi:role="line"
              x="-339.13602"
              y="1222.2766"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53199);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-5-2-8">　 </tspan><tspan
              sodipodi:role="line"
              x="-339.13602"
              y="1242.55"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53199);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-2-6">Y</tspan></text>
       </g>
       <g
@@ -25326,7 +16665,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53197);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.24225"
            y="1222.2357"
            id="text17040-4-2-8-9-0-1"
@@ -25335,12 +16674,12 @@
              sodipodi:role="line"
              x="-339.24225"
              y="1222.2357"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53197);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-4-4-4">&quot;</tspan><tspan
              sodipodi:role="line"
              x="-339.24225"
              y="1242.5092"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53197);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431737">'</tspan></text>
       </g>
       <g
@@ -25364,7 +16703,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53195);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.4498"
            y="1222.3301"
            id="text17040-4-2-8-2-1"
@@ -25373,14 +16712,14 @@
              sodipodi:role="line"
              x="-339.4498"
              y="1222.3301"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53195);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-93-0">　 <tspan
-   style="font-weight:bold;fill:url(#linearGradient53195)"
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
    id="tspan497577">↓</tspan></tspan><tspan
              sodipodi:role="line"
              x="-339.4498"
              y="1242.9608"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53195);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13622-9-6">J</tspan></text>
       </g>
       <g
@@ -25410,7 +16749,7 @@
            style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-300.00226"
              x="1206.1366"
              id="tspan17020-6-8-1-65-9"
@@ -25439,11 +16778,11 @@
            id="text17018-5-4-1-0-8-9-6"
            y="1240.7465"
            x="-339.34808"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53193);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"
            transform="scale(-1,1)"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53193);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1240.7465"
              x="-339.34808"
              id="tspan17020-6-0-9-54-1-2-9"
@@ -25470,7 +16809,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53191);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-338.82483"
            y="1222.3021"
            id="text17040-4-2-8-7-7-3"
@@ -25479,12 +16818,12 @@
              sodipodi:role="line"
              x="-338.82483"
              y="1222.3021"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53191);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-7-6">*</tspan><tspan
              sodipodi:role="line"
              x="-338.82483"
              y="1242.5756"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53191);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431679">8</tspan></text>
       </g>
       <g
@@ -25510,11 +16849,11 @@
            id="text17018-5-4-1-04-6"
            y="1240.7145"
            x="-339.57993"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53189);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"
            transform="scale(-1,1)"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53189);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1240.7145"
              x="-339.57993"
              id="tspan17020-6-0-9-88-1"
@@ -25541,7 +16880,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53187);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.41284"
            y="1240.7152"
            id="text17018-5-4-1-5-2-9-2"
@@ -25551,7 +16890,7 @@
              id="tspan17020-6-0-9-9-5-6-9"
              x="-339.41284"
              y="1240.7152"
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:url(#linearGradient53187);fill-opacity:1;stroke-width:1px">num</tspan></text>
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">num</tspan></text>
       </g>
       <g
          style="display:inline;stroke:#280b0b;stroke-width:0.9375"
@@ -25574,7 +16913,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53185);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.50134"
            y="1222.1345"
            id="text17040-4-2-8-6-2-5"
@@ -25583,12 +16922,12 @@
              sodipodi:role="line"
              x="-339.50134"
              y="1222.1345"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53185);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13626-43-8">&gt;</tspan><tspan
              sodipodi:role="line"
              x="-339.50134"
              y="1242.408"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53185);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431721">.</tspan></text>
       </g>
       <g
@@ -25612,7 +16951,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53183);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-338.87173"
            y="1222.1963"
            id="text17040-4-2-8-7-8-2"
@@ -25621,12 +16960,12 @@
              sodipodi:role="line"
              x="-338.87173"
              y="1222.1963"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53183);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-4-8">(</tspan><tspan
              sodipodi:role="line"
              x="-338.87173"
              y="1242.4697"
-             style="font-size:16.21875px;line-height:1.25;fill:url(#linearGradient53183);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431683">9</tspan></text>
       </g>
       <g
@@ -25650,7 +16989,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53181);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.04285"
            y="1222.2181"
            id="text17040-4-2-8-1-49-7-5"
@@ -25659,12 +16998,12 @@
              sodipodi:role="line"
              x="-339.04285"
              y="1222.2181"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53181);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan13618-4-6-4">+</tspan><tspan
              sodipodi:role="line"
              x="-339.04285"
              y="1242.4916"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53181);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431745">=</tspan></text>
       </g>
       <g
@@ -25694,7 +17033,7 @@
            style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.89148"
              x="1205.8728"
              id="tspan17020-6-8-1-65-9-0"
@@ -25727,7 +17066,7 @@
            style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.8959"
              x="1206.351"
              id="tspan17020-6-8-1-65-9-0-9"
@@ -25760,7 +17099,7 @@
            style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="-299.76242"
              x="1206.1559"
              id="tspan17020-6-8-1-65-9-0-9-3"
@@ -25787,7 +17126,7 @@
            style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
         <text
            xml:space="preserve"
-           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:url(#linearGradient53179);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            x="-339.05746"
            y="1222.4298"
            id="text17040-4-2-8-7-4-8"
@@ -25796,12 +17135,12 @@
              sodipodi:role="line"
              x="-339.05746"
              y="1222.4298"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53179);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan17060-8-2-76-6-8-0">&amp;</tspan><tspan
              sodipodi:role="line"
              x="-339.05746"
              y="1242.7032"
-             style="font-size:16.21874809px;line-height:1.25;fill:url(#linearGradient53179);fill-opacity:1;stroke-width:1px"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
              id="tspan431675">7</tspan></text>
       </g>
       <g
@@ -25827,17 +17166,18 @@
            id="text17018-5-4-1-5-7"
            y="1240.7736"
            x="-323.73273"
-           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:url(#linearGradient53177);fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
            xml:space="preserve"
            transform="scale(-1,1)"
            sodipodi:linespacing="0%"><tspan
-             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:url(#linearGradient53177);fill-opacity:1;stroke-width:1px"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px"
              y="1240.7736"
              x="-323.73273"
              id="tspan17020-6-0-9-9-36"
              sodipodi:role="line">fn</tspan></text>
       </g>
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120372"
@@ -25846,6 +17186,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120382"
@@ -25854,6 +17195,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120392"
@@ -25862,6 +17204,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120402"
@@ -25870,6 +17213,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120412"
@@ -25878,6 +17222,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120422"
@@ -25886,6 +17231,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120432"
@@ -25894,6 +17240,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120442"
@@ -25902,6 +17249,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120452"
@@ -25910,6 +17258,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120462"
@@ -25918,6 +17267,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120472"
@@ -25926,6 +17276,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120482"
@@ -25934,6 +17285,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120492"
@@ -25942,6 +17294,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120502"
@@ -25950,6 +17303,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120512"
@@ -25958,6 +17312,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120522"
@@ -25966,6 +17321,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120532"
@@ -25974,6 +17330,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120542"
@@ -25982,6 +17339,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120552"
@@ -25990,6 +17348,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120562"
@@ -25998,6 +17357,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120572"
@@ -26006,6 +17366,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120582"
@@ -26014,6 +17375,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120592"
@@ -26022,6 +17384,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120602"
@@ -26030,6 +17393,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120612"
@@ -26038,6 +17402,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120622"
@@ -26046,6 +17411,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120632"
@@ -26054,6 +17420,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120642"
@@ -26062,6 +17429,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120652"
@@ -26070,6 +17438,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120662"
@@ -26078,6 +17447,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120672"
@@ -26086,6 +17456,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g120682"
@@ -26094,6 +17465,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131248"
@@ -26102,6 +17474,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131258"
@@ -26110,6 +17483,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131268"
@@ -26118,6 +17492,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131278"
@@ -26126,6 +17501,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131288"
@@ -26134,6 +17510,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131298"
@@ -26142,6 +17519,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131308"
@@ -26150,6 +17528,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131318"
@@ -26158,6 +17537,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131328"
@@ -26166,6 +17546,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131338"
@@ -26174,6 +17555,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131348"
@@ -26182,6 +17564,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131358"
@@ -26190,6 +17573,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131368"
@@ -26198,6 +17582,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131378"
@@ -26206,6 +17591,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131388"
@@ -26214,6 +17600,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131398"
@@ -26222,6 +17609,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131408"
@@ -26230,6 +17618,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131418"
@@ -26238,6 +17627,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131428"
@@ -26246,6 +17636,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131438"
@@ -26254,6 +17645,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131448"
@@ -26262,6 +17654,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131458"
@@ -26270,6 +17663,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131468"
@@ -26278,6 +17672,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131478"
@@ -26286,6 +17681,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131488"
@@ -26294,6 +17690,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131498"
@@ -26302,6 +17699,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131508"
@@ -26310,6 +17708,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131518"
@@ -26318,6 +17717,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131528"
@@ -26326,6 +17726,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131538"
@@ -26334,6 +17735,7 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131548"
@@ -26342,11 +17744,6016 @@
          width="100%"
          height="100%" />
       <use
+         style="display:inline"
          x="0"
          y="0"
          xlink:href="#g131558"
          id="use25592"
          transform="matrix(0.8660254,0.5,-0.5,0.8660254,94.879177,741.94658)"
+         width="100%"
+         height="100%" />
+    </g>
+    <g
+       style="display:none"
+       inkscape:label="Dvorak"
+       id="g53306"
+       inkscape:groupmode="layer">
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,214.13951,-888.91866)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53308"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53310"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53312"
+           y="1222.3207"
+           x="306.06317"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53314"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3207"
+             x="306.06317"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53316"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5941"
+             x="306.06317"
+             sodipodi:role="line">X</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,142.14803,-904.09208)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53318"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53320"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53322"
+           y="1222.3324"
+           x="306.06589"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53324"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3324"
+             x="306.06589"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53326"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6058"
+             x="306.06589"
+             sodipodi:role="line">K</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-48.176374,-876.0168)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53328"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53330"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53332"
+           y="1222.2959"
+           x="306.06183"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53334"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2959"
+             x="306.06183"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53336"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5693"
+             x="306.06183"
+             sodipodi:role="line">Q</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,214.1434,-1025.0088)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53338"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53340"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53342"
+           y="1222.3461"
+           x="306.05954"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53344"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3461"
+             x="306.05954"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53346"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6195"
+             x="306.05954"
+             sodipodi:role="line">Y</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-50.563254,-944.06137)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53348"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53350"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53352"
+           y="1222.3474"
+           x="306.07187"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53354"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3474"
+             x="306.07187"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53356"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6208"
+             x="306.07187"
+             sodipodi:role="line">O</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,286.04627,-952.93684)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53358"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53360"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.57327"
+           y="1240.7863"
+           id="text53362"><tspan
+             sodipodi:role="line"
+             id="tspan53364"
+             x="305.57327"
+             y="1240.7863"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">tab</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,142.12902,-1108.204)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53366"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53368"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53370"
+           y="1222.3486"
+           x="306.08371"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53372"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3486"
+             x="306.08371"
+             sodipodi:role="line">$</tspan><tspan
+             id="tspan53374"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6221"
+             x="306.08371"
+             sodipodi:role="line">4</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-52.943114,-1012.0501)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53376"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53378"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53380"
+           y="1222.3463"
+           x="306.07706"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53382"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3463"
+             x="306.07706"
+             sodipodi:role="line">&lt;　</tspan><tspan
+             id="tspan53384"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6198"
+             x="306.07706"
+             sodipodi:role="line">,</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,46.683531,-901.62578)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53386"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53388"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53390"
+           y="1222.3168"
+           x="306.05801"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53392"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3168"
+             x="306.05801"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53394"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5902"
+             x="306.05801"
+             sodipodi:role="line">J</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,142.15492,-972.12722)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53396"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53398"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53400"
+           y="1222.3358"
+           x="306.05942"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53402"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3358"
+             x="306.05942"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53404"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6093"
+             x="306.05942"
+             sodipodi:role="line">U</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,44.303241,-1037.7104)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53406"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53408"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53410"
+           y="1222.3564"
+           x="306.06232"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53412"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3564"
+             x="306.06232"
+             sodipodi:role="line">&gt;　</tspan><tspan
+             id="tspan53414"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6299"
+             x="306.06232"
+             sodipodi:role="line">.</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-257.04133,-806.01389)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53416"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53418"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53420"
+           y="1240.8011"
+           x="305.57193"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.8011"
+             x="305.57193"
+             id="tspan53422"
+             sodipodi:role="line">pgdn</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-197.46608,-947.85579)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53424"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53426"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53428"
+           y="1222.3274"
+           x="306.07935"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53430"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3274"
+             x="306.07935"
+             sodipodi:role="line">&quot;　</tspan><tspan
+             id="tspan53432"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6008"
+             x="306.07935"
+             sodipodi:role="line">'</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,45.490431,-969.67212)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53434"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53436"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53438"
+           y="1222.3406"
+           x="306.06302"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53440"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3406"
+             x="306.06302"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53442"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.614"
+             x="306.06302"
+             sodipodi:role="line">E</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-191.53212,-880.09438)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53444"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53446"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53448"
+           y="1222.3375"
+           x="306.07413"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53450"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3375"
+             x="306.07413"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53452"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.611"
+             x="306.07413"
+             sodipodi:role="line">A</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-185.60125,-812.3125)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53454"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53456"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53458"
+           y="1222.3287"
+           x="306.07346"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53460"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3287"
+             x="306.07346"
+             sodipodi:role="line">:　</tspan><tspan
+             id="tspan53462"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6022"
+             x="306.07346"
+             sodipodi:role="line">;</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,286.05891,-867.83059)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53464"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53466"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53468"
+           y="1240.7787"
+           x="305.56143"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7787"
+             x="305.56143"
+             id="tspan53470"
+             sodipodi:role="line">esc</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,214.14644,-1093.0463)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53472"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53474"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53476"
+           y="1222.3518"
+           x="306.05667"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53478"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3518"
+             x="306.05667"
+             sodipodi:role="line">%</tspan><tspan
+             id="tspan53480"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6252"
+             x="306.05667"
+             sodipodi:role="line">5</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-268.88613,-941.52652)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53482"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53484"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53486"
+           y="1222.3271"
+           x="306.04913"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53488"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3271"
+             x="306.04913"
+             sodipodi:role="line">~</tspan><tspan
+             id="tspan53490"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6006"
+             x="306.04913"
+             sodipodi:role="line">`</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,214.14127,-956.98504)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53492"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53494"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53496"
+           y="1222.3534"
+           x="306.06152"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53498"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3534"
+             x="306.06152"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53500"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6268"
+             x="306.06152"
+             sodipodi:role="line">I</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-274.83214,-1009.3537)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53502"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53504"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53506"
+           y="1240.8219"
+           x="305.57275"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.8219"
+             x="305.57275"
+             id="tspan53508"
+             sodipodi:role="line">prog</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,43.116791,-1105.7145)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53510"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53512"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53514"
+           y="1222.3405"
+           x="306.06177"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53516"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3405"
+             x="306.06177"
+             sodipodi:role="line">#</tspan><tspan
+             id="tspan53518"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6139"
+             x="306.06177"
+             sodipodi:role="line">3</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-262.96233,-873.77228)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53520"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53522"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53524"
+           y="1221.9446"
+           x="305.3317"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1221.9446"
+             x="305.3317"
+             id="tspan53526"
+             sodipodi:role="line">+</tspan><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1239.136"
+             x="305.3317"
+             sodipodi:role="line"
+             id="tspan8470">=</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,142.14577,-1040.1722)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53528"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53530"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53532"
+           y="1222.3484"
+           x="306.06799"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53534"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3484"
+             x="306.06799"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53536"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6218"
+             x="306.06799"
+             sodipodi:role="line">P</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0666667,0,0,1.0666667,286.05356,-1038.0581)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53538"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53540"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.56647"
+           y="1240.8077"
+           id="text53542"><tspan
+             sodipodi:role="line"
+             id="tspan53544"
+             x="305.56647"
+             y="1240.8077"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">led</tspan></text>
+      </g>
+      <g
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-203.38179,-1015.6677)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53546"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53548"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53550"
+           y="1222.363"
+           x="306.06342"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53552"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.363"
+             x="306.06342"
+             sodipodi:role="line">!</tspan><tspan
+             id="tspan53554"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6365"
+             x="306.06342"
+             sodipodi:role="line">1</tspan><tspan
+             id="tspan53556"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1262.9099"
+             x="306.06342"
+             sodipodi:role="line" /></text>
+      </g>
+      <g
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-55.303949,-1080.0453)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53558"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53560"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           id="text53562"
+           y="1222.3507"
+           x="306.0643"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53564"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3507"
+             x="306.0643"
+             sodipodi:role="line">@</tspan><tspan
+             id="tspan53566"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.6241"
+             x="306.0643"
+             sodipodi:role="line">2</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53568"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(0.72746494,-0.78011064,-0.78011064,-0.72746494,1428.2305,1735.8026)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53570"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="matrix(0,-1,-1,0,0,0)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-1208.2581"
+           y="-299.71399"
+           id="text53572"><tspan
+             sodipodi:role="line"
+             id="tspan53574"
+             x="-1208.2581"
+             y="-299.71399"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px">shift</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53576"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(0.58094832,-0.89458197,-0.89458197,-0.58094832,1564.6778,1552.7408)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53578"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="matrix(0,-1,-1,0,0,0)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-1207.9635"
+           y="-300.0101"
+           id="text53580"><tspan
+             sodipodi:role="line"
+             id="tspan53582"
+             x="-1207.9635"
+             y="-300.0101"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px">cmd</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53584"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(0.41677989,-0.98187187,-0.98187187,-0.41677989,1666.958,1348.3102)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53586"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="matrix(0,-1,-1,0,0,0)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-1208.2621"
+           y="-299.74393"
+           id="text53588"><tspan
+             sodipodi:role="line"
+             id="tspan53590"
+             x="-1208.2621"
+             y="-299.74393"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px">bksp</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53592"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(0.23994779,-1.0393281,-1.0393281,-0.23994779,1732.5157,1129.6766)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53594"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="matrix(0,-1,-1,0,0,0)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-1208.0164"
+           y="-299.89603"
+           id="text53596"><tspan
+             sodipodi:role="line"
+             id="tspan53598"
+             x="-1208.0164"
+             y="-299.89603"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px">ctrl</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.94181079,0.50076967,-0.50076967,0.94181079,868.76092,-619.34828)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53600"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53602"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="321.10257"
+           y="1241.0553"
+           id="text53604"><tspan
+             sodipodi:role="line"
+             id="tspan53606"
+             x="321.10257"
+             y="1241.0553"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px">fn</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1702.6759,-813.84037)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53608"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53610"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53612"
+           y="1222.2958"
+           x="-339.78146"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53614"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2958"
+             x="-339.78146"
+             sodipodi:role="line">     \</tspan><tspan
+             id="tspan53616"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5692"
+             x="-339.78146"
+             sodipodi:role="line">Z</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1714.1059,-949.41692)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53618"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53620"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53622"
+           y="1222.2899"
+           x="-339.37842"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53624"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2899"
+             x="-339.37842"
+             sodipodi:role="line">　 ]</tspan><tspan
+             id="tspan53626"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5634"
+             x="-339.37842"
+             sodipodi:role="line">L</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.2449,-1040.9495)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53628"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53630"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53632"
+           y="1222.2686"
+           x="-339.25903"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53634"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2686"
+             x="-339.25903"
+             sodipodi:role="line">　  {</tspan><tspan
+             id="tspan53636"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.542"
+             x="-339.25903"
+             sodipodi:role="line">G</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.1399,-1093.6864)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53638"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53640"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-338.92413"
+           y="1222.293"
+           id="text53642"><tspan
+             sodipodi:role="line"
+             x="-338.92413"
+             y="1222.293"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan53644">^</tspan><tspan
+             id="tspan53646"
+             sodipodi:role="line"
+             x="-338.92413"
+             y="1242.5664"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px">6</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1774.1531,-807.71962)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53648"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53650"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53652"
+           y="1222.1923"
+           x="-339.47693"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53654"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.1923"
+             x="-339.47693"
+             sodipodi:role="line">|</tspan><tspan
+             id="tspan53656"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.4657"
+             x="-339.47693"
+             sodipodi:role="line">\</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1472.146,-1038.8002)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53658"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53660"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53662"
+           y="1222.3184"
+           x="-339.0274"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53664"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3184"
+             x="-339.0274"
+             sodipodi:role="line">　  }</tspan><tspan
+             id="tspan53666"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5918"
+             x="-339.0274"
+             sodipodi:role="line">C</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.8007,-889.53633)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53668"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53670"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53672"
+           y="1222.2408"
+           x="-339.54364"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53674"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2408"
+             x="-339.54364"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53676"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5143"
+             x="-339.54364"
+             sodipodi:role="line">B</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1471.1723,-970.75849)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53678"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53680"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53682"
+           y="1222.3026"
+           x="-339.22824"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53684"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3026"
+             x="-339.22824"
+             sodipodi:role="line">　 <tspan
+   id="tspan53686"
+   style="font-weight:bold;fill:#000000;fill-opacity:1">↑</tspan></tspan><tspan
+             id="tspan53688"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.9333"
+             x="-339.22824"
+             sodipodi:role="line">T</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1719.7529,-1017.2486)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53690"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53692"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53694"
+           y="1222.322"
+           x="-339.11005"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53696"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.322"
+             x="-339.11005"
+             sodipodi:role="line"
+             dx="2">)</tspan><tspan
+             id="tspan53698"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5955"
+             x="-339.11005"
+             sodipodi:role="line">0</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1708.3849,-881.63966)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53700"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53702"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53704"
+           y="1222.3026"
+           x="-339.57346"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53706"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3026"
+             x="-339.57346"
+             sodipodi:role="line" /><tspan
+             id="tspan53708"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.576"
+             x="-339.57346"
+             sodipodi:role="line">S</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.925,-868.22115)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53710"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53712"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <g
+           style="display:inline;opacity:0.98000004"
+           id="g53714"
+           transform="matrix(-0.93749997,0,0,0.93749997,1120.3489,1368.1151)">
+          <g
+             id="g53716">
+            <g
+               id="g53718"
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)">
+              <g
+                 clip-path="url(#clipPath27934-0-2)"
+                 id="g53720">
+                <g
+                   transform="translate(691.04896,562.95467)"
+                   id="g53722">
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path53724"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     d="M 0,0 C -0.58026667,0 -1.0570667,-0.9568 -1.0570667,-2.6048 -1.0570667,-4.2549333 -0.6304,-7.7568 0,-7.7578667 0.63253333,-7.7568 1.0592,-4.2549333 1.0592,-2.6048 1.0592,-0.9568 0.58133333,0 0,0" />
+                </g>
+              </g>
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,850.06879,-155.51468)"
+               id="g53726">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path53728"
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                 d="M 0,0 -0.92693333,1.7834667 -1.3888,1.5413333 l 0.928,-1.78026663 z" />
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,853.03492,-157.44253)"
+               id="g53730">
+              <path
+                 inkscape:connector-curvature="0"
+                 id="path53732"
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                 d="M 0,0 -0.46186667,0.24213333 -1.3898667,-1.5413333 -0.928,-1.7802667 Z" />
+            </g>
+            <g
+               id="g53734"
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)">
+              <g
+                 clip-path="url(#clipPath27954-5-3)"
+                 id="g53736">
+                <g
+                   transform="translate(681.07189,567.62443)"
+                   id="g53738">
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path53740"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     d="M 0,0 C -1.1146667,0.26453333 -1.7557333,-0.40853333 -1.5530667,-1.7386667 -1.1296,-4.5258667 -0.13013333,-6.24 2.0010667,-6.7584 3.6224,-7.1552 8.0714667,-7.3077333 8.0714667,-7.3077333 7.1616,-2.8629333 2.7317333,-0.6496 0,0" />
+                </g>
+              </g>
+            </g>
+            <g
+               id="g53742"
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)">
+              <g
+                 clip-path="url(#clipPath27966-5-4)"
+                 id="g53744">
+                <g
+                   transform="translate(689.2,559.44117)"
+                   id="g53746">
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path53748"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     d="M 0,0 C 0,0 -1.9466667,0.15466667 -3.2565333,0.04266667 -4.9248,-0.09706667 -5.9370667,-0.65706667 -5.9370667,-2.5898667 c 0,-2.8309333 2.7210667,-4.1077333 4.112,-4.0330666 C -1.2501333,-6.5952 -0.26773333,-5.4176 0.0768,-4.5034667 0.30186667,-3.9029333 0.4032,-3.3472 0.32106667,-2.4832 0.27093333,-1.9541333 0,0 0,0" />
+                </g>
+              </g>
+            </g>
+            <g
+               id="g53750"
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)">
+              <g
+                 clip-path="url(#clipPath27978-9-3)"
+                 id="g53752">
+                <g
+                   transform="translate(701.01355,567.624)"
+                   id="g53754">
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path53756"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     d="m 0,0 c -2.7306667,-0.6496 -7.1605333,-2.8618667 -8.0714667,-7.3077333 0,0 4.4490667,0.1536 6.0693334,0.5504 2.13439997,0.5173333 3.1328,2.2314666 3.5552,5.0197333 C 1.7557333,-0.40746667 1.1146667,0.2656 0,0" />
+                </g>
+              </g>
+            </g>
+            <g
+               id="g53758"
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)">
+              <g
+                 clip-path="url(#clipPath27990-8-0)"
+                 id="g53760">
+                <g
+                   transform="translate(696.14272,559.48384)"
+                   id="g53762">
+                  <path
+                     inkscape:connector-curvature="0"
+                     id="path53764"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     d="m 0,0 c -1.3098667,0.112 -3.2565333,-0.04373333 -3.2565333,-0.04373333 0,0 -0.2730667,-1.95306667 -0.3210667,-2.48319997 C -3.6597333,-3.392 -3.5594667,-3.9456 -3.3333333,-4.5472 c 0.3434666,-0.9130667 1.3269333,-2.0906667 1.8986666,-2.1194667 1.39200003,-0.0736 4.1173334,1.2032 4.1173334,4.0341334 C 2.6826667,-0.69973333 1.6672,-0.13973333 0,0" />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1470.214,-902.70803)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53766"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53768"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53770"
+           y="1222.2788"
+           x="-339.44339"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53772"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2788"
+             x="-339.44339"
+             sodipodi:role="line" /><tspan
+             id="tspan53774"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5522"
+             x="-339.44339"
+             sodipodi:role="line">W</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1569.4515,-1013.3779)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53776"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53778"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53780"
+           y="1222.1907"
+           x="-339.09845"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53782"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.1907"
+             x="-339.09845"
+             sodipodi:role="line">　  [</tspan><tspan
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.4641"
+             x="-339.09845"
+             sodipodi:role="line"
+             id="tspan8466">R</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1567.2849,-945.37997)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53786"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53788"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53790"
+           y="1222.1902"
+           x="-339.2933"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53792"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.1902"
+             x="-339.2933"
+             sodipodi:role="line">　 <tspan
+   id="tspan53794"
+   style="font-weight:bold;fill:#000000;fill-opacity:1">→</tspan></tspan><tspan
+             id="tspan53796"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.8209"
+             x="-339.2933"
+             sodipodi:role="line">N</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.6718,-904.93614)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53798"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53800"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53802"
+           y="1222.3152"
+           x="-339.65924"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53804"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3152"
+             x="-339.65924"
+             sodipodi:role="line">　</tspan><tspan
+             id="tspan53806"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5886"
+             x="-339.65924"
+             sodipodi:role="line">M</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.5812,-957.61395)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53808"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53810"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53812"
+           y="1222.2842"
+           x="-339.33786"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53814"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2842"
+             x="-339.33786"
+             sodipodi:role="line">　 <tspan
+   id="tspan53816"
+   style="font-weight:bold;fill:#000000;fill-opacity:1">←</tspan></tspan><tspan
+             id="tspan53818"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.9149"
+             x="-339.33786"
+             sodipodi:role="line">D</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.3659,-1025.6374)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53820"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53822"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53824"
+           y="1222.2766"
+           x="-339.13602"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53826"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2766"
+             x="-339.13602"
+             sodipodi:role="line">　 </tspan><tspan
+             id="tspan53828"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.55"
+             x="-339.13602"
+             sodipodi:role="line">F</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1779.8371,-875.56022)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53830"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53832"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53834"
+           y="1222.2357"
+           x="-339.24225"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53836"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2357"
+             x="-339.24225"
+             sodipodi:role="line">_</tspan><tspan
+             id="tspan53838"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5092"
+             x="-339.24225"
+             sodipodi:role="line">-</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.4484,-972.98353)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53840"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53842"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53844"
+           y="1222.3301"
+           x="-339.4498"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53846"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3301"
+             x="-339.4498"
+             sodipodi:role="line">　 <tspan
+   id="tspan53848"
+   style="font-weight:bold;fill:#000000;fill-opacity:1">↓</tspan></tspan><tspan
+             id="tspan53850"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.9608"
+             x="-339.4498"
+             sodipodi:role="line">H</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53852"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-0.23994779,-1.0393281,1.0393281,-0.23994779,-215.31795,1128.9619)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53854"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="1206.1366"
+           y="-300.00226"
+           id="text53856"
+           transform="matrix(0,1,-1,0,0,0)"><tspan
+             sodipodi:role="line"
+             id="tspan53858"
+             x="1206.1366"
+             y="-300.00226"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">ctrl</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.4186,-1038.4711)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53860"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53862"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.34808"
+           y="1240.7465"
+           id="text53864"><tspan
+             sodipodi:role="line"
+             id="tspan53866"
+             x="-339.34808"
+             y="1240.7465"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">any</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1473.117,-1106.8078)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53868"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53870"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53872"
+           y="1222.3021"
+           x="-338.82483"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53874"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.3021"
+             x="-338.82483"
+             sodipodi:role="line">*</tspan><tspan
+             id="tspan53876"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5756"
+             x="-338.82483"
+             sodipodi:role="line">8</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.6659,-953.33868)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53878"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53880"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.57993"
+           y="1240.7145"
+           id="text53882"><tspan
+             sodipodi:role="line"
+             id="tspan53884"
+             x="-339.57993"
+             y="1240.7145"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">enter</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1791.3626,-1011.1743)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53886"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53888"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53890"
+           y="1240.7152"
+           x="-339.41284"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7152"
+             x="-339.41284"
+             id="tspan53892"
+             sodipodi:role="line">num</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1565.1303,-877.32287)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53894"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53896"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53898"
+           y="1222.1345"
+           x="-339.50134"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53900"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.1345"
+             x="-339.50134"
+             sodipodi:role="line" /><tspan
+             id="tspan53902"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.408"
+             x="-339.50134"
+             sodipodi:role="line">V</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1571.5843,-1081.3824)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53904"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53906"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53908"
+           y="1222.1963"
+           x="-338.87173"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53910"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.1963"
+             x="-338.87173"
+             sodipodi:role="line">(</tspan><tspan
+             id="tspan53912"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.4697"
+             x="-338.87173"
+             sodipodi:role="line">9</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1785.553,-943.33277)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53914"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53916"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           id="text53918"
+           y="1222.2181"
+           x="-339.04285"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53920"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.2181"
+             x="-339.04285"
+             sodipodi:role="line">?</tspan><tspan
+             id="tspan53922"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.4916"
+             x="-339.04285"
+             sodipodi:role="line">/</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53924"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-0.41677987,-0.98187187,0.98187187,-0.41677987,-149.69554,1347.7894)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53926"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="1205.8728"
+           y="-299.89148"
+           id="text53928"
+           transform="matrix(1.2715259e-8,1,-1,1.2715259e-8,0,0)"><tspan
+             sodipodi:role="line"
+             id="tspan53930"
+             x="1205.8728"
+             y="-299.89148"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">space</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53932"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-0.58094832,-0.89458197,0.89458197,-0.58094832,-47.316468,1552.4009)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53934"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="1206.351"
+           y="-299.8959"
+           id="text53936"
+           transform="matrix(0,1,-1,0,0,0)"><tspan
+             sodipodi:role="line"
+             id="tspan53938"
+             x="1206.351"
+             y="-299.8959"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">alt</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g53940"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-0.72746494,-0.78011064,0.78011064,-0.72746494,89.257721,1735.6236)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect53942"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           sodipodi:linespacing="0%"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="1206.1559"
+           y="-299.76242"
+           id="text53944"
+           transform="matrix(0,1,-1,0,0,0)"><tspan
+             sodipodi:role="line"
+             id="tspan53946"
+             x="1206.1559"
+             y="-299.76242"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">shift</tspan></text>
+      </g>
+      <g
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.0299,-1109.153)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53948"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53950"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"
+           id="text53952"
+           y="1222.4298"
+           x="-339.05746"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"><tspan
+             id="tspan53954"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.4298"
+             x="-339.05746"
+             sodipodi:role="line">&amp;</tspan><tspan
+             id="tspan53956"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.7032"
+             x="-339.05746"
+             sodipodi:role="line">7</tspan></text>
+      </g>
+      <g
+         transform="matrix(-0.94181079,0.50076968,0.50076968,0.94181079,649.04929,-619.97866)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g53958"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect53960"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-323.73273"
+           y="1240.7736"
+           id="text53962"><tspan
+             sodipodi:role="line"
+             id="tspan53964"
+             x="-323.73273"
+             y="1240.7736"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px">fn</tspan></text>
+      </g>
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.44165,1214.3195)"
+         id="use53966"
+         xlink:href="#g53308"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.26137,1214.3021)"
+         id="use53968"
+         xlink:href="#g53318"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.49019,1214.1882)"
+         id="use53970"
+         xlink:href="#g53328"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.43783,1062.1082)"
+         id="use53972"
+         xlink:href="#g53338"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.44119,1138.1174)"
+         id="use53974"
+         xlink:href="#g53348"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.73849,1138.2313)"
+         id="use53976"
+         xlink:href="#g53358"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.28029,985.95777)"
+         id="use53978"
+         xlink:href="#g53366"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.3934,1061.9566)"
+         id="use53980"
+         xlink:href="#g53376"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.70255,1214.243)"
+         id="use53982"
+         xlink:href="#g53386"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.25448,1138.181)"
+         id="use53984"
+         xlink:href="#g53396"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.54553,1062.0166)"
+         id="use53986"
+         xlink:href="#g53406"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(615.69332,1214.4324)"
+         id="use53988"
+         xlink:href="#g53416"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.18057,1062.2196)"
+         id="use53990"
+         xlink:href="#g53424"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.53623,1138.1363)"
+         id="use53992"
+         xlink:href="#g53434"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.14361,1138.3134)"
+         id="use53994"
+         xlink:href="#g53444"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.11634,1214.4646)"
+         id="use53996"
+         xlink:href="#g53454"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.69415,1214.5005)"
+         id="use53998"
+         xlink:href="#g53464"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.43475,985.99574)"
+         id="use54000"
+         xlink:href="#g53472"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(615.55172,1062.2414)"
+         id="use54002"
+         xlink:href="#g53482"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.43998,1138.2344)"
+         id="use54004"
+         xlink:href="#g53492"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(615.50008,986.1415)"
+         id="use54006"
+         xlink:href="#g53502"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.62045,985.87835)"
+         id="use54008"
+         xlink:href="#g53510"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(615.62389,1138.3459)"
+         id="use54010"
+         xlink:href="#g53520"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.26358,1062.0808)"
+         id="use54012"
+         xlink:href="#g53528"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(617.69419,986.32251)"
+         id="use54014"
+         xlink:href="#g53538"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.19579,986.1415)"
+         id="use54016"
+         xlink:href="#g53546"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(616.31696,985.80247)"
+         id="use54018"
+         xlink:href="#g53558"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.90630779,-0.42261826,0.42261826,0.90630779,291.79048,1519.8085)"
+         id="use54020"
+         xlink:href="#g53568"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.90630779,-0.42261826,0.42261826,0.90630779,278.62145,1517.8899)"
+         id="use54022"
+         xlink:href="#g53576"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.8660254,-0.5,0.5,0.8660254,251.35734,1597.3192)"
+         id="use54024"
+         xlink:href="#g53584"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.88294759,-0.46947156,0.46947156,0.88294759,249.77448,1591.4659)"
+         id="use54026"
+         xlink:href="#g53592"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.8660254,-0.5,0.5,0.8660254,36.700871,1500.299)"
+         id="use54028"
+         xlink:href="#g53600"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.97459,1215.9926)"
+         id="use54030"
+         xlink:href="#g53608"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.60395,1063.7808)"
+         id="use54032"
+         xlink:href="#g53618"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.43798,1062.8581)"
+         id="use54034"
+         xlink:href="#g53628"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.50478,986.63568)"
+         id="use54036"
+         xlink:href="#g53638"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.58874,1216.1381)"
+         id="use54038"
+         xlink:href="#g53648"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.77844,1063.1064)"
+         id="use54040"
+         xlink:href="#g53658"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-688.16558,1214.9371)"
+         id="use54042"
+         xlink:href="#g53668"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.12569,1139.2197)"
+         id="use54044"
+         xlink:href="#g53678"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.35064,987.7223)"
+         id="use54046"
+         xlink:href="#g53690"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.77995,1139.8587)"
+         id="use54048"
+         xlink:href="#g53700"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-688.46178,1214.8909)"
+         id="use54050"
+         xlink:href="#g53710"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.38373,1215.3254)"
+         id="use54052"
+         xlink:href="#g53766"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.68543,1063.2844)"
+         id="use54054"
+         xlink:href="#g53776"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.94656,1139.436)"
+         id="use54056"
+         xlink:href="#g53786"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.86479,1215.1462)"
+         id="use54058"
+         xlink:href="#g53798"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.94599,1138.8634)"
+         id="use54060"
+         xlink:href="#g53808"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.73077,1062.7368)"
+         id="use54062"
+         xlink:href="#g53820"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.28239,1140.1339)"
+         id="use54064"
+         xlink:href="#g53830"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.64148,1139.0373)"
+         id="use54066"
+         xlink:href="#g53840"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.88294759,0.46947156,-0.46947156,0.88294759,-143.49967,879.8157)"
+         id="use54068"
+         xlink:href="#g53852"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.94989,986.73554)"
+         id="use54070"
+         xlink:href="#g53860"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.63799,986.97155)"
+         id="use54072"
+         xlink:href="#g53868"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-688.23438,1138.6331)"
+         id="use54074"
+         xlink:href="#g53878"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-685.81414,987.9621)"
+         id="use54076"
+         xlink:href="#g53886"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.22776,1215.4942)"
+         id="use54078"
+         xlink:href="#g53894"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.38096,987.13957)"
+         id="use54080"
+         xlink:href="#g53904"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-686.00215,1064.0477)"
+         id="use54082"
+         xlink:href="#g53914"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,-119.3894,839.13905)"
+         id="use54084"
+         xlink:href="#g53924"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.90630779,0.42261826,-0.42261826,0.90630779,-207.74496,876.93325)"
+         id="use54086"
+         xlink:href="#g53932"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.90630779,0.42261826,-0.42261826,0.90630779,-220.96104,878.65245)"
+         id="use54088"
+         xlink:href="#g53940"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="translate(-687.22298,986.90671)"
+         id="use54090"
+         xlink:href="#g53948"
+         y="0"
+         x="0" />
+      <use
+         style="display:inline"
+         height="100%"
+         width="100%"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,94.879177,741.94658)"
+         id="use54092"
+         xlink:href="#g53958"
+         y="0"
+         x="0" />
+    </g>
+    <g
+       inkscape:groupmode="layer"
+       id="layer2"
+       inkscape:label="Colemak"
+       style="display:none">
+      <g
+         id="g68012"
+         transform="matrix(1.3325056,0,0,1.3325056,-1318.0336,-1801.2418)"
+         style="stroke:#999999" />
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120372-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,214.1395,-888.91868)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120374-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06317"
+           y="1222.3207"
+           id="text17040-4-2-8-6-6-4"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06317"
+             y="1222.3207"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-4-1">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06317"
+             y="1242.5941"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392650-0">B</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120382-4"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,142.14802,-904.09208)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120384-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06589"
+           y="1222.3324"
+           id="text17040-4-2-8-6-1-2"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06589"
+             y="1222.3324"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-9-2">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06589"
+             y="1242.6058"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392654-4">V</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120392-0"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-48.176384,-876.01678)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120394-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06183"
+           y="1222.2959"
+           id="text17040-4-2-8-6-2-9"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06183"
+             y="1222.2959"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-43-1">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06183"
+             y="1242.5693"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392662-7">X</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120402-6"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,214.14339,-1025.0088)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120404-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.05954"
+           y="1222.3461"
+           id="text17040-4-2-8-1-7-0"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.05954"
+             y="1222.3461"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-5-2-5">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.05954"
+             y="1242.6195"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-2-67">T</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120412-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-50.563264,-944.06138)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120414-5"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.07187"
+           y="1222.3474"
+           id="text17040-4-2-8-0-8"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.07187"
+             y="1222.3474"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-40-1">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.07187"
+             y="1242.6208"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-91-55">S</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120422-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,286.04627,-952.93678)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120424-6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-04-1"
+           y="1240.7863"
+           x="305.57327"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7863"
+             x="305.57327"
+             id="tspan17020-6-0-9-88-6"
+             sodipodi:role="line">tab</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120432-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,142.12901,-1108.204)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120434-8"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.08371"
+           y="1222.3486"
+           id="text17040-4-2-8-7-4-5"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.08371"
+             y="1222.3486"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-8-7">$</tspan><tspan
+             sodipodi:role="line"
+             x="306.08371"
+             y="1242.6221"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431653-6">4</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120442-3"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-52.943124,-1012.0501)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120444-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.07706"
+           y="1222.3463"
+           id="text17040-4-2-8-1-41-9"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.07706"
+             y="1222.3463"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-8-7">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.07706"
+             y="1242.6198"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan349792-5">W</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120452-5"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,46.683526,-901.62578)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120454-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.05801"
+           y="1222.3168"
+           id="text17040-4-2-8-6-0-5"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.05801"
+             y="1222.3168"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-64-74">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.05801"
+             y="1242.5902"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392658-2">C</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120462-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,142.15491,-972.12718)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120464-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.05942"
+           y="1222.3358"
+           id="text17040-4-2-8-2-2"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.05942"
+             y="1222.3358"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-93-3">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.05942"
+             y="1242.6093"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-9-8">F</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120472-4"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,44.303236,-1037.7104)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120474-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06232"
+           y="1222.3564"
+           id="text17040-4-2-8-1-72-2"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06232"
+             y="1222.3564"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-99-9">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06232"
+             y="1242.6299"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392612-9">E</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120482-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-257.04133,-806.01386)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120484-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.57193"
+           y="1240.8011"
+           id="text17018-5-4-1-7-93-0-3"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             id="tspan17020-6-0-9-5-9-7-7"
+             x="305.57193"
+             y="1240.8011"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">pgdn</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120492-1"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-197.46608,-947.85578)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120494-4"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.07935"
+           y="1222.3274"
+           id="text17040-4-2-8-1-49-9"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.07935"
+             y="1222.3274"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-4-2">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.07935"
+             y="1242.6008"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan349788-8">Q</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120502-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,45.490426,-969.67208)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120504-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06302"
+           y="1222.3406"
+           id="text17040-4-2-8-11-48"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06302"
+             y="1222.3406"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-0-47">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06302"
+             y="1242.614"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-34-0">D</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120512-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-191.53212,-880.09438)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120514-5"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.07413"
+           y="1222.3375"
+           id="text17040-4-2-8-9-2"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.07413"
+             y="1222.3375"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-60-0">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.07413"
+             y="1242.611"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-4-7">A</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120522-4"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-185.60125,-812.31247)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120524-5"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.07346"
+           y="1222.3287"
+           id="text17040-4-2-8-6-28-1"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.07346"
+             y="1222.3287"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-0-8">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.07346"
+             y="1242.6022"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392666-0">Z</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120532-5"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,286.05891,-867.83058)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120534-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.56143"
+           y="1240.7787"
+           id="text17018-5-4-1-7-0-0"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             id="tspan17020-6-0-9-5-5-3"
+             x="305.56143"
+             y="1240.7787"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">esc</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120542-3"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,214.14643,-1093.0463)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120544-7"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.05667"
+           y="1222.3518"
+           id="text17040-4-2-8-7-0-8"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.05667"
+             y="1222.3518"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-1-4">%</tspan><tspan
+             sodipodi:role="line"
+             x="306.05667"
+             y="1242.6252"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431657-1">5</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120552-6"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-268.88613,-941.52648)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120554-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.04913"
+           y="1222.3271"
+           id="text17040-4-2-8-1-49-0-5"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.04913"
+             y="1222.3271"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-4-9-3">~</tspan><tspan
+             sodipodi:role="line"
+             x="306.04913"
+             y="1242.6006"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392676-9">`</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120562-1"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,214.14126,-956.98498)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120564-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06152"
+           y="1222.3534"
+           id="text17040-4-2-8-8-4"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06152"
+             y="1222.3534"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-3-3">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06152"
+             y="1242.6268"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392640-1">G</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120572-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-274.83214,-1009.3537)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120574-8"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.57275"
+           y="1240.8219"
+           id="text17018-5-4-1-5-2-3-8"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             id="tspan17020-6-0-9-9-5-7-6"
+             x="305.57275"
+             y="1240.8219"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">prog</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120582-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0665042,-0.0186159,0.0186159,1.0665042,43.116786,-1105.7145)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120584-6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06177"
+           y="1222.3405"
+           id="text17040-4-2-8-7-7-35"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06177"
+             y="1222.3405"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-7-4">#</tspan><tspan
+             sodipodi:role="line"
+             x="306.06177"
+             y="1242.6139"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431649-3">3</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120592-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-262.96233,-873.77228)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120594-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="305.56534"
+           y="1240.7872"
+           id="text17018-5-4-1-58-8-4"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             id="tspan17020-6-0-9-7-2-6"
+             x="305.56534"
+             y="1240.7872"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">pgup</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120602-1"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,142.14576,-1040.1722)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120604-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06799"
+           y="1222.3484"
+           id="text17040-4-2-8-1-4-9"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06799"
+             y="1222.3484"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-7-3">　</tspan><tspan
+             sodipodi:role="line"
+             x="306.06799"
+             y="1242.6218"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392616-3">R</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120612-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0666667,0,0,1.0666667,286.05356,-1038.0581)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120614-5"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-0-8-7-6"
+           y="1240.8077"
+           x="305.56647"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.8077"
+             x="305.56647"
+             id="tspan17020-6-0-9-54-1-8-2"
+             sodipodi:role="line">led</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120622-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0626077,-0.09296613,0.09296613,1.0626077,-203.38179,-1015.6677)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120624-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.06342"
+           y="1222.363"
+           id="text17040-4-2-8-7-34-6"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.06342"
+             y="1222.363"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-2-9">!</tspan><tspan
+             sodipodi:role="line"
+             x="306.06342"
+             y="1242.6365"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392680-5">1</tspan><tspan
+             sodipodi:role="line"
+             x="306.06342"
+             y="1262.9099"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan392682-2" /></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120632-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(1.0660169,-0.03722613,0.03722613,1.0660169,-55.303954,-1080.0453)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120634-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="306.0643"
+           y="1222.3507"
+           id="text17040-4-2-8-7-8-9"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="306.0643"
+             y="1222.3507"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-4-4">@</tspan><tspan
+             sodipodi:role="line"
+             x="306.0643"
+             y="1242.6241"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431645-2">2</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.72746494,-0.78011064,-0.78011064,-0.72746494,1428.2305,1735.8026)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g120642-1"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect120644-7"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           id="text17018-5-7-8-9-7-9-3-6"
+           y="-299.71399"
+           x="-1208.2581"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           transform="matrix(0,-1,-1,0,0,0)"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.71399"
+             x="-1208.2581"
+             id="tspan17020-6-8-1-7-9-0-7-5"
+             sodipodi:role="line">shift</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.58094832,-0.89458197,-0.89458197,-0.58094832,1564.6778,1552.7408)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g120652-3"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect120654-4"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           id="text17018-5-7-8-9-7-9-0"
+           y="-300.0101"
+           x="-1207.9635"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           transform="matrix(0,-1,-1,0,0,0)"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-300.0101"
+             x="-1207.9635"
+             id="tspan17020-6-8-1-7-9-0-2"
+             sodipodi:role="line">cmd</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.41677989,-0.98187187,-0.98187187,-0.41677989,1666.958,1348.3102)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g120662-1"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect120664-1"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           id="text17018-5-7-8-9-7-94"
+           y="-299.74393"
+           x="-1208.2621"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           transform="matrix(0,-1,-1,0,0,0)"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.74393"
+             x="-1208.2621"
+             id="tspan17020-6-8-1-7-9-08"
+             sodipodi:role="line">bksp</tspan></text>
+      </g>
+      <g
+         transform="matrix(0.23994779,-1.0393281,-1.0393281,-0.23994779,1732.5157,1129.6766)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g120672-8"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect120674-8"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           id="text17018-5-7-8-9-4"
+           y="-299.89603"
+           x="-1208.0164"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           transform="matrix(0,-1,-1,0,0,0)"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:end;writing-mode:lr-tb;text-anchor:end;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.89603"
+             x="-1208.0164"
+             id="tspan17020-6-8-1-7-7"
+             sodipodi:role="line">ctrl</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g120682-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(0.94181079,0.50076967,-0.50076967,0.94181079,868.76092,-619.34825)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect120684-7"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-5-8-0-2"
+           y="1241.0553"
+           x="321.10257"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1241.0553"
+             x="321.10257"
+             id="tspan17020-6-0-9-9-49-3-9"
+             sodipodi:role="line">fn</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131248-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1702.6759,-813.84034)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131250-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.78146"
+           y="1222.2958"
+           id="text17040-4-2-8-6-28-8-7"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.78146"
+             y="1222.2958"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431725-9">?   \</tspan><tspan
+             sodipodi:role="line"
+             x="-339.78146"
+             y="1242.5692"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431729-8">/</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131258-3"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1714.1059,-949.41688)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131260-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.37842"
+           y="1222.2899"
+           id="text17040-4-2-8-1-49-7-7"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.37842"
+             y="1222.2899"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-4-6-1">　 ]</tspan><tspan
+             sodipodi:role="line"
+             x="-339.37842"
+             y="1242.5634"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431709-9">P</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131268-3"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.2449,-1040.9495)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131270-6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.25903"
+           y="1222.2686"
+           id="text17040-4-2-8-1-4-6-3"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.25903"
+             y="1222.2686"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-7-9-7">　  {</tspan><tspan
+             sodipodi:role="line"
+             x="-339.25903"
+             y="1242.542"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431697-2">U</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131278-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.1399,-1093.6864)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131280-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17040-4-2-8-7-0-6-2"
+           y="1222.293"
+           x="-338.92413"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             id="tspan17060-8-2-76-6-1-9-8"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1222.293"
+             x="-338.92413"
+             sodipodi:role="line">^</tspan><tspan
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1242.5664"
+             x="-338.92413"
+             sodipodi:role="line"
+             id="tspan431671-1">6</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131288-0"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1774.1531,-807.71959)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131290-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.47693"
+           y="1222.1923"
+           id="text17040-4-2-8-6-28-8-2-4"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.47693"
+             y="1222.1923"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-0-5-3-5">_   |</tspan><tspan
+             sodipodi:role="line"
+             x="-339.47693"
+             y="1242.4657"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431733-8">-</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131298-5"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1472.146,-1038.8002)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131300-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.0274"
+           y="1222.3184"
+           id="text17040-4-2-8-1-72-5-1"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.0274"
+             y="1222.3184"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-5-82-3-7">　  }</tspan><tspan
+             sodipodi:role="line"
+             x="-339.0274"
+             y="1242.5918"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-99-8-7">I</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131308-5"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.8007,-889.53628)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131310-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.54364"
+           y="1222.2408"
+           id="text17040-4-2-8-6-6-3-9"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.54364"
+             y="1222.2408"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-9-6-7-2">　</tspan><tspan
+             sodipodi:role="line"
+             x="-339.54364"
+             y="1242.5143"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-4-4-2">N</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131318-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1471.1723,-970.75848)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131320-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.22824"
+           y="1222.3026"
+           id="text17040-4-2-8-11-4-2"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.22824"
+             y="1222.3026"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-0-4-8">　 <tspan
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
+   id="tspan497575-2">↑</tspan></tspan><tspan
+             sodipodi:role="line"
+             x="-339.22824"
+             y="1242.9333"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-34-4-5">K</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131328-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1719.7529,-1017.2486)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131330-7"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.11005"
+           y="1222.322"
+           id="text17040-4-2-8-7-34-0-8"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.11005"
+             y="1222.322"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-2-7-6">)</tspan><tspan
+             sodipodi:role="line"
+             x="-339.11005"
+             y="1242.5955"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431687-6">0</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131338-6"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1708.3849,-881.63968)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131340-6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.57346"
+           y="1222.3026"
+           id="text17040-4-2-8-9-0-3"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.57346"
+             y="1222.3026"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-4-4-8">:</tspan><tspan
+             sodipodi:role="line"
+             x="-339.57346"
+             y="1242.576"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431741-1">;</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131348-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.925,-868.22108)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131350-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <g
+           transform="matrix(-0.93749997,0,0,0.93749997,1120.3489,1368.1151)"
+           id="g28239-6"
+           style="display:inline;opacity:0.98000004">
+          <g
+             id="g28213-8">
+            <g
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)"
+               id="g27930-9">
+              <g
+                 id="g27932-9"
+                 clip-path="url(#clipPath27934-0-2-8)">
+                <g
+                   id="g27938-3"
+                   transform="translate(691.04896,562.95467)">
+                  <path
+                     d="M 0,0 C -0.58026667,0 -1.0570667,-0.9568 -1.0570667,-2.6048 -1.0570667,-4.2549333 -0.6304,-7.7568 0,-7.7578667 0.63253333,-7.7568 1.0592,-4.2549333 1.0592,-2.6048 1.0592,-0.9568 0.58133333,0 0,0"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     id="path27940-0"
+                     inkscape:connector-curvature="0" />
+                </g>
+              </g>
+            </g>
+            <g
+               id="g27942-3"
+               transform="matrix(1.25,0,0,-1.25,850.06879,-155.51468)">
+              <path
+                 d="M 0,0 -0.92693333,1.7834667 -1.3888,1.5413333 l 0.928,-1.78026663 z"
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                 id="path27944-5"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               id="g27946-4"
+               transform="matrix(1.25,0,0,-1.25,853.03492,-157.44253)">
+              <path
+                 d="M 0,0 -0.46186667,0.24213333 -1.3898667,-1.5413333 -0.928,-1.7802667 Z"
+                 style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                 id="path27948-7"
+                 inkscape:connector-curvature="0" />
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)"
+               id="g27950-1">
+              <g
+                 id="g27952-8"
+                 clip-path="url(#clipPath27954-5-3-6)">
+                <g
+                   id="g27958-0"
+                   transform="translate(681.07189,567.62443)">
+                  <path
+                     d="M 0,0 C -1.1146667,0.26453333 -1.7557333,-0.40853333 -1.5530667,-1.7386667 -1.1296,-4.5258667 -0.13013333,-6.24 2.0010667,-6.7584 3.6224,-7.1552 8.0714667,-7.3077333 8.0714667,-7.3077333 7.1616,-2.8629333 2.7317333,-0.6496 0,0"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     id="path27960-8"
+                     inkscape:connector-curvature="0" />
+                </g>
+              </g>
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)"
+               id="g27962-1">
+              <g
+                 id="g27964-9"
+                 clip-path="url(#clipPath27966-5-4-1)">
+                <g
+                   id="g27970-8"
+                   transform="translate(689.2,559.44117)">
+                  <path
+                     d="M 0,0 C 0,0 -1.9466667,0.15466667 -3.2565333,0.04266667 -4.9248,-0.09706667 -5.9370667,-0.65706667 -5.9370667,-2.5898667 c 0,-2.8309333 2.7210667,-4.1077333 4.112,-4.0330666 C -1.2501333,-6.5952 -0.26773333,-5.4176 0.0768,-4.5034667 0.30186667,-3.9029333 0.4032,-3.3472 0.32106667,-2.4832 0.27093333,-1.9541333 0,0 0,0"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     id="path27972-0"
+                     inkscape:connector-curvature="0" />
+                </g>
+              </g>
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)"
+               id="g27974-8">
+              <g
+                 id="g27976-1"
+                 clip-path="url(#clipPath27978-9-3-9)">
+                <g
+                   id="g27982-2"
+                   transform="translate(701.01355,567.624)">
+                  <path
+                     d="m 0,0 c -2.7306667,-0.6496 -7.1605333,-2.8618667 -8.0714667,-7.3077333 0,0 4.4490667,0.1536 6.0693334,0.5504 2.13439997,0.5173333 3.1328,2.2314666 3.5552,5.0197333 C 1.7557333,-0.40746667 1.1146667,0.2656 0,0"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     id="path27984-9"
+                     inkscape:connector-curvature="0" />
+                </g>
+              </g>
+            </g>
+            <g
+               transform="matrix(1.25,0,0,-1.25,-13.120007,548.84921)"
+               id="g27986-7">
+              <g
+                 id="g27988-9"
+                 clip-path="url(#clipPath27990-8-0-6)">
+                <g
+                   id="g27994-1"
+                   transform="translate(696.14272,559.48384)">
+                  <path
+                     d="m 0,0 c -1.3098667,0.112 -3.2565333,-0.04373333 -3.2565333,-0.04373333 0,0 -0.2730667,-1.95306667 -0.3210667,-2.48319997 C -3.6597333,-3.392 -3.5594667,-3.9456 -3.3333333,-4.5472 c 0.3434666,-0.9130667 1.3269333,-2.0906667 1.8986666,-2.1194667 1.39200003,-0.0736 4.1173334,1.2032 4.1173334,4.0341334 C 2.6826667,-0.69973333 1.6672,-0.13973333 0,0"
+                     style="fill:#000000;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1px"
+                     id="path27996-4"
+                     inkscape:connector-curvature="0" />
+                </g>
+              </g>
+            </g>
+          </g>
+        </g>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131358-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1470.214,-902.70798)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131360-7"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.44339"
+           y="1222.2788"
+           id="text17040-4-2-8-6-0-2-3"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.44339"
+             y="1222.2788"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-64-7-9">&lt;</tspan><tspan
+             sodipodi:role="line"
+             x="-339.44339"
+             y="1242.5522"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431717-5">,</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131368-0"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1569.4515,-1013.3779)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131370-8"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.09845"
+           y="1222.1907"
+           id="text17040-4-2-8-1-41-1-5"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.09845"
+             y="1222.1907"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-5-28-0-4">　  [</tspan><tspan
+             sodipodi:role="line"
+             x="-339.09845"
+             y="1242.4641"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-8-5-4">O</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131378-1"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1567.2849,-945.37998)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131380-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.2933"
+           y="1222.1902"
+           id="text17040-4-2-8-0-4-1"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.2933"
+             y="1222.1902"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-40-0-5">　 <tspan
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
+   id="tspan497573-8">→</tspan></tspan><tspan
+             sodipodi:role="line"
+             x="-339.2933"
+             y="1242.8209"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-91-5-9">L</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131388-2"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.6718,-904.93608)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131390-1"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.65924"
+           y="1222.3152"
+           id="text17040-4-2-8-6-1-7-5"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.65924"
+             y="1222.3152"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-9-5-1-8">　</tspan><tspan
+             sodipodi:role="line"
+             x="-339.65924"
+             y="1242.5886"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-9-1-9">M</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131398-3"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.5812,-957.61388)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131400-4"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.33786"
+           y="1222.2842"
+           id="text17040-4-2-8-8-2-4"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.33786"
+             y="1222.2842"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-4-0-0">　 <tspan
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
+   id="tspan497579-3">←</tspan></tspan><tspan
+             sodipodi:role="line"
+             x="-339.33786"
+             y="1242.9149"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-3-6-2">H</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131408-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1302.3659,-1025.6374)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131410-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.13602"
+           y="1222.2766"
+           id="text17040-4-2-8-1-7-7-1"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.13602"
+             y="1222.2766"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-5-2-8-6">　 </tspan><tspan
+             sodipodi:role="line"
+             x="-339.13602"
+             y="1242.55"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-2-6-5">Y</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131418-7"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1779.8371,-875.56018)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131420-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.24225"
+           y="1222.2357"
+           id="text17040-4-2-8-9-0-1-5"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.24225"
+             y="1222.2357"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-4-4-4-9">&quot;</tspan><tspan
+             sodipodi:role="line"
+             x="-339.24225"
+             y="1242.5092"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431737-2">'</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131428-4"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.4484,-972.98348)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131430-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.4498"
+           y="1222.3301"
+           id="text17040-4-2-8-2-1-5"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.4498"
+             y="1222.3301"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-93-0-0">　 <tspan
+   style="font-weight:bold;fill:#000000;fill-opacity:1"
+   id="tspan497577-1">↓</tspan></tspan><tspan
+             sodipodi:role="line"
+             x="-339.4498"
+             y="1242.9608"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13622-9-6-0">J</tspan></text>
+      </g>
+      <g
+         transform="matrix(-0.23994779,-1.0393281,1.0393281,-0.23994779,-215.31795,1128.9619)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g131438-3"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect131440-8"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="matrix(0,1,-1,0,0,0)"
+           id="text17018-5-7-8-4-2-7"
+           y="-300.00226"
+           x="1206.1366"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-300.00226"
+             x="1206.1366"
+             id="tspan17020-6-8-1-65-9-6"
+             sodipodi:role="line">ctrl</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131448-0"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.4186,-1038.4711)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131450-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-0-8-9-6-2"
+           y="1240.7465"
+           x="-339.34808"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7465"
+             x="-339.34808"
+             id="tspan17020-6-0-9-54-1-2-9-5"
+             sodipodi:role="line">any</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131458-6"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0665042,-0.0186159,-0.0186159,1.0665042,1473.117,-1106.8078)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131460-7"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-338.82483"
+           y="1222.3021"
+           id="text17040-4-2-8-7-7-3-1"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-338.82483"
+             y="1222.3021"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-7-6-0">*</tspan><tspan
+             sodipodi:role="line"
+             x="-338.82483"
+             y="1242.5756"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431679-4">8</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131468-6"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1230.6659,-953.33868)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131470-3"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-04-6-2"
+           y="1240.7145"
+           x="-339.57993"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7145"
+             x="-339.57993"
+             id="tspan17020-6-0-9-88-1-5"
+             sodipodi:role="line">enter</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131478-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1791.3626,-1011.1743)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131480-0"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.41284"
+           y="1240.7152"
+           id="text17018-5-4-1-5-2-9-2-3"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             id="tspan17020-6-0-9-9-5-6-9-5"
+             x="-339.41284"
+             y="1240.7152"
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px">num</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131488-8"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1565.1303,-877.32288)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131490-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.50134"
+           y="1222.1345"
+           id="text17040-4-2-8-6-2-5-1"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.50134"
+             y="1222.1345"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13626-43-8-3">&gt;</tspan><tspan
+             sodipodi:role="line"
+             x="-339.50134"
+             y="1242.408"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431721-5">.</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131498-4"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0660169,-0.03722613,-0.03722613,1.0660169,1571.5843,-1081.3824)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131500-2"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-338.87173"
+           y="1222.1963"
+           id="text17040-4-2-8-7-8-2-1"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-338.87173"
+             y="1222.1963"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-4-8-7">(</tspan><tspan
+             sodipodi:role="line"
+             x="-338.87173"
+             y="1242.4697"
+             style="font-size:16.21875px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431683-0">9</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131508-0"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0626077,-0.09296613,-0.09296613,1.0626077,1785.553,-943.33278)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131510-6"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.04285"
+           y="1222.2181"
+           id="text17040-4-2-8-1-49-7-5-8"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             sodipodi:role="line"
+             x="-339.04285"
+             y="1222.2181"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan13618-4-6-4-3">+</tspan><tspan
+             sodipodi:role="line"
+             x="-339.04285"
+             y="1242.4916"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431745-1">=</tspan></text>
+      </g>
+      <g
+         transform="matrix(-0.41677987,-0.98187187,0.98187187,-0.41677987,-149.69554,1347.7894)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g131518-4"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect131520-4"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="matrix(1.2715259e-8,1,-1,1.2715259e-8,0,0)"
+           id="text17018-5-7-8-4-2-5-4"
+           y="-299.89148"
+           x="1205.8728"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312519px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.89148"
+             x="1205.8728"
+             id="tspan17020-6-8-1-65-9-0-6"
+             sodipodi:role="line">space</tspan></text>
+      </g>
+      <g
+         transform="matrix(-0.58094832,-0.89458197,0.89458197,-0.58094832,-47.316474,1552.4009)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g131528-0"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect131530-8"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="matrix(0,1,-1,0,0,0)"
+           id="text17018-5-7-8-4-2-5-9-4"
+           y="-299.8959"
+           x="1206.351"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.8959"
+             x="1206.351"
+             id="tspan17020-6-8-1-65-9-0-9-4"
+             sodipodi:role="line">alt</tspan></text>
+      </g>
+      <g
+         transform="matrix(-0.72746494,-0.78011064,0.78011064,-0.72746494,89.257713,1735.6236)"
+         inkscape:tile-y0="1204.37"
+         inkscape:tile-x0="295.07874"
+         id="g131538-5"
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375">
+        <rect
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+           id="rect131540-9"
+           width="54.921261"
+           height="45.354332"
+           x="295.07874"
+           y="1204.37"
+           inkscape:tile-cx="322.46063"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-x0="295"
+           inkscape:tile-y0="1149.37" />
+        <text
+           transform="matrix(0,1,-1,0,0,0)"
+           id="text17018-5-7-8-4-2-5-9-9-3"
+           y="-299.76242"
+           x="1206.1559"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;writing-mode:lr-tb;text-anchor:start;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="-299.76242"
+             x="1206.1559"
+             id="tspan17020-6-8-1-65-9-0-9-3-3"
+             sodipodi:role="line">shift</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131548-5"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-1.0666667,0,0,1.0666667,1374.0299,-1109.153)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131550-9"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           xml:space="preserve"
+           style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:0%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           x="-339.05746"
+           y="1222.4298"
+           id="text17040-4-2-8-7-4-8-8"
+           sodipodi:linespacing="0%"
+           transform="scale(-1,1)"><tspan
+             sodipodi:role="line"
+             x="-339.05746"
+             y="1222.4298"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan17060-8-2-76-6-8-0-6">&amp;</tspan><tspan
+             sodipodi:role="line"
+             x="-339.05746"
+             y="1242.7032"
+             style="font-size:16.21874809px;line-height:1.25;fill:#000000;fill-opacity:1;stroke-width:1px"
+             id="tspan431675-0">7</tspan></text>
+      </g>
+      <g
+         style="display:inline;stroke:#280b0b;stroke-width:0.9375"
+         id="g131558-9"
+         inkscape:tile-x0="295.07874"
+         inkscape:tile-y0="1204.37"
+         transform="matrix(-0.94181079,0.50076968,0.50076968,0.94181079,649.04929,-619.97863)">
+        <rect
+           inkscape:tile-y0="1149.37"
+           inkscape:tile-x0="295"
+           inkscape:tile-h="45.354332"
+           inkscape:tile-w="54.921261"
+           inkscape:tile-cy="1172.0472"
+           inkscape:tile-cx="322.46063"
+           y="1204.37"
+           x="295.07874"
+           height="45.354332"
+           width="54.921261"
+           id="rect131560-8"
+           style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:0.31372549;fill-rule:evenodd;stroke:none;stroke-width:0.99921262;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate" />
+        <text
+           id="text17018-5-4-1-5-7-7"
+           y="1240.7736"
+           x="-323.73273"
+           style="font-style:normal;font-weight:normal;font-size:12px;line-height:0%;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;display:inline;opacity:0.98000004;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           xml:space="preserve"
+           transform="scale(-1,1)"
+           sodipodi:linespacing="0%"><tspan
+             style="font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:13.75312424px;line-height:125%;font-family:'Gotham Rounded';-inkscape-font-specification:'Gotham Rounded, Normal';text-align:center;writing-mode:lr-tb;text-anchor:middle;fill:#000000;fill-opacity:1;stroke-width:1px"
+             y="1240.7736"
+             x="-323.73273"
+             id="tspan17020-6-0-9-9-36-0"
+             sodipodi:role="line">fn</tspan></text>
+      </g>
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120372-7"
+         id="use25466-2"
+         transform="translate(617.44165,1214.3195)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120382-4"
+         id="use25468-0"
+         transform="translate(617.26137,1214.3021)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120392-0"
+         id="use25470-7"
+         transform="translate(616.49019,1214.1882)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120402-6"
+         id="use25472-9"
+         transform="translate(617.43783,1062.1082)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120412-8"
+         id="use25474-0"
+         transform="translate(616.44119,1138.1174)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120422-8"
+         id="use25476-5"
+         transform="translate(617.73849,1138.2313)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120432-2"
+         id="use25478-3"
+         transform="translate(617.28029,985.95781)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120442-3"
+         id="use25480-6"
+         transform="translate(616.3934,1061.9566)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120452-5"
+         id="use25482-2"
+         transform="translate(616.70255,1214.243)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120462-9"
+         id="use25484-5"
+         transform="translate(617.25448,1138.181)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120472-4"
+         id="use25486-8"
+         transform="translate(616.54553,1062.0166)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120482-2"
+         id="use25488-1"
+         transform="translate(615.69332,1214.4324)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120492-1"
+         id="use25490-8"
+         transform="translate(616.18057,1062.2196)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120502-7"
+         id="use25492-3"
+         transform="translate(616.53623,1138.1363)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120512-8"
+         id="use25494-3"
+         transform="translate(616.14361,1138.3134)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120522-4"
+         id="use25496-7"
+         transform="translate(616.11634,1214.4646)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120532-5"
+         id="use25498-4"
+         transform="translate(617.69415,1214.5005)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120542-3"
+         id="use25500-0"
+         transform="translate(617.43475,985.99571)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120552-6"
+         id="use25502-0"
+         transform="translate(615.55172,1062.2414)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120562-1"
+         id="use25504-1"
+         transform="translate(617.43998,1138.2344)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120572-7"
+         id="use25506-1"
+         transform="translate(615.50008,986.14151)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120582-9"
+         id="use25508-5"
+         transform="translate(616.62045,985.87831)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120592-8"
+         id="use25510-8"
+         transform="translate(615.62389,1138.3459)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120602-1"
+         id="use25512-2"
+         transform="translate(617.26358,1062.0808)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120612-8"
+         id="use25514-5"
+         transform="translate(617.69419,986.32251)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120622-7"
+         id="use25516-0"
+         transform="translate(616.19579,986.14151)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120632-9"
+         id="use25518-8"
+         transform="translate(616.31696,985.80251)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120642-1"
+         id="use25520-5"
+         transform="matrix(0.90630779,-0.42261826,0.42261826,0.90630779,291.79048,1519.8085)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120652-3"
+         id="use25522-1"
+         transform="matrix(0.90630779,-0.42261826,0.42261826,0.90630779,278.62145,1517.8899)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120662-1"
+         id="use25524-0"
+         transform="matrix(0.8660254,-0.5,0.5,0.8660254,251.35734,1597.3192)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120672-8"
+         id="use25526-3"
+         transform="matrix(0.88294759,-0.46947156,0.46947156,0.88294759,249.77448,1591.4659)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g120682-2"
+         id="use25528-6"
+         transform="matrix(0.8660254,-0.5,0.5,0.8660254,36.700866,1500.299)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131248-2"
+         id="use25530-7"
+         transform="translate(-686.97459,1215.9926)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131258-3"
+         id="use25532-5"
+         transform="translate(-686.60395,1063.7808)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131268-3"
+         id="use25534-1"
+         transform="translate(-687.43798,1062.8581)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131278-7"
+         id="use25536-5"
+         transform="translate(-687.50478,986.63571)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131288-0"
+         id="use25538-8"
+         transform="translate(-686.58874,1216.1381)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131298-5"
+         id="use25540-5"
+         transform="translate(-686.77844,1063.1064)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131308-5"
+         id="use25542-4"
+         transform="translate(-688.16558,1214.9371)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131318-2"
+         id="use25544-3"
+         transform="translate(-687.12569,1139.2197)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131328-2"
+         id="use25546-8"
+         transform="translate(-686.35064,987.72231)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131338-6"
+         id="use25548-4"
+         transform="translate(-686.77995,1139.8587)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131348-8"
+         id="use25550-1"
+         transform="translate(-688.46178,1214.8909)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131358-8"
+         id="use25552-9"
+         transform="translate(-687.38373,1215.3254)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131368-0"
+         id="use25554-8"
+         transform="translate(-686.68543,1063.2844)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131378-1"
+         id="use25556-7"
+         transform="translate(-686.94656,1139.436)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131388-2"
+         id="use25558-4"
+         transform="translate(-687.86479,1215.1462)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131398-3"
+         id="use25560-8"
+         transform="translate(-687.94599,1138.8634)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131408-9"
+         id="use25562-3"
+         transform="translate(-687.73077,1062.7368)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131418-7"
+         id="use25564-6"
+         transform="translate(-686.28239,1140.1339)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131428-4"
+         id="use25566-3"
+         transform="translate(-687.64148,1139.0373)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131438-3"
+         id="use25568-8"
+         transform="matrix(0.88294759,0.46947156,-0.46947156,0.88294759,-143.49966,879.81575)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131448-0"
+         id="use25570-3"
+         transform="translate(-687.94989,986.73551)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131458-6"
+         id="use25572-9"
+         transform="translate(-686.63799,986.97151)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131468-6"
+         id="use25574-8"
+         transform="translate(-688.23438,1138.6331)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131478-9"
+         id="use25576-8"
+         transform="translate(-685.81414,987.96211)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131488-8"
+         id="use25578-3"
+         transform="translate(-687.22776,1215.4942)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131498-4"
+         id="use25580-8"
+         transform="translate(-686.38096,987.13961)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131508-0"
+         id="use25582-8"
+         transform="translate(-686.00215,1064.0477)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131518-4"
+         id="use25584-9"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,-119.38939,839.13903)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131528-0"
+         id="use25586-9"
+         transform="matrix(0.90630779,0.42261826,-0.42261826,0.90630779,-207.74495,876.93329)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131538-5"
+         id="use25588-6"
+         transform="matrix(0.90630779,0.42261826,-0.42261826,0.90630779,-220.96103,878.65249)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131548-5"
+         id="use25590-0"
+         transform="translate(-687.22298,986.90671)"
+         width="100%"
+         height="100%" />
+      <use
+         style="display:inline"
+         x="0"
+         y="0"
+         xlink:href="#g131558-9"
+         id="use25592-5"
+         transform="matrix(0.8660254,0.5,-0.5,0.8660254,94.879185,741.94659)"
          width="100%"
          height="100%" />
     </g>
@@ -28603,8 +26010,4 @@
          y="1794.9358"
          id="tspan80168">(-25°)</tspan></text>
   </g>
-  <g
-     id="g68012"
-     transform="matrix(1.3325056,0,0,1.3325056,-1318.0336,-1801.2418)"
-     style="stroke:#999999" />
 </svg>


### PR DESCRIPTION
Also added kerning to the close paren ")" on the "0" key in order to improve the visual alignment on QWERTY layout.

Relinked the clones so everything is linked to the correct objects. In order to add another layer, the easiest way to do it is now to copy the file, then copy the QWERTY layer, then use "Paste in Place" (assuming Inkscape) to paste the objects and clones into a new layer in the original file. This will put everything in the correct location, and all the new clones will be linked to the new layer's legend objects (if the QWERTY layer is copied without the intermediate file, the new clones will be linked to the QWERTY labels instead of the new layer's labels).